### PR TITLE
Add MAC and MAL composition patterns

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,8 @@ pub mod memora;
 pub mod lattice_osr;
 pub mod trellis;
 pub mod mag;
+pub mod mal;
+pub mod mac;
 #[cfg(feature = "internal")]
 pub mod gradient;
 #[cfg(not(feature = "internal"))]

--- a/core/src/mac.rs
+++ b/core/src/mac.rs
@@ -1,0 +1,950 @@
+/// MAC (Memory As Context) composition.
+///
+/// Architecture:
+///   embed → read_only(embedded) → h_t → concat(h_t, embedded) → QKV(assembled)
+///         → full causal attn(2s) → extract y_t(s:) → memory.step(y_t) → reflective_y
+///         → y_t * sigmoid(reflective_y) → W_O → unembed → loss
+///
+/// Most expressive: memory provides context for attention, then reflects on attention output.
+/// Two memory operations per step: read-only (context) + step (reflective gate).
+
+use crate::tensor::{matmul_f32, transpose_f32, cross_entropy_loss, sigmoid_f32};
+use crate::model::{MAGConfig, MAGParams, MemoryRuleKind, MemoryLevelParams};
+use crate::delta_rule::{MemoryRule, DeltaRule, delta_rule_read_only, delta_rule_read_only_backward};
+use crate::titans_lmm::TitansLMM;
+use crate::hebbian_rule::HebbianRule;
+use crate::moneta::{Moneta, moneta_read_only, moneta_read_only_backward};
+use crate::yaad::{YAAD, yaad_read_only, yaad_read_only_backward};
+use crate::memora::{MEMORA, memora_read_only, memora_read_only_backward};
+use crate::lattice_osr::{LatticeOSR, lattice_read_only, lattice_read_only_backward};
+use crate::trellis::{Trellis, trellis_read_only, trellis_read_only_backward};
+use crate::conductor::{Pulse, ContextState, ErrorBuffer};
+use crate::mag::MemoryCache;
+
+/// Cache for MAC forward pass.
+pub struct MACForwardCache {
+    pub embedded: Vec<f32>,       // (s, d)
+    // Read-only memory context
+    pub h_t: Vec<f32>,            // (s, d) — read from current M
+    pub q_mem_read: Vec<f32>,     // for read_only backward
+    pub frozen_m_read: Vec<f32>,  // M used for read_only
+    // Assembled and attention
+    pub assembled: Vec<f32>,      // (2s, d) = concat(h_t, embedded)
+    pub q: Vec<f32>,              // (2s, d)
+    pub k: Vec<f32>,              // (2s, d)
+    pub v: Vec<f32>,              // (2s, d)
+    pub attn_out: Vec<f32>,       // (2s, d)
+    pub attn_weights: Vec<f32>,
+    // y_t extraction and reflective memory
+    pub y_t: Vec<f32>,            // (s, d) — extracted from attn_out[s:]
+    pub memory_cache: MemoryCache,
+    pub reflective_y: Vec<f32>,   // (s, d) — memory output from step(y_t)
+    // Reflective gate
+    pub reflective_gate: Vec<f32>, // sigmoid(reflective_y): (s, d)
+    pub gated_out: Vec<f32>,       // y_t * reflective_gate: (s, d)
+    // Post-gate
+    pub projected: Vec<f32>,
+    pub logits: Vec<f32>,
+}
+
+/// Read-only dispatch (no memory update, just M @ q).
+fn read_only_dispatch(
+    cfg: &MAGConfig,
+    level_params: &MemoryLevelParams,
+    embedded: &[f32],
+    m_state: &[f32],
+    s: usize,
+    d: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    match cfg.memory_rule {
+        MemoryRuleKind::Moneta => moneta_read_only(level_params, embedded, m_state, s, d, cfg.d_hidden),
+        MemoryRuleKind::YAAD => yaad_read_only(level_params, embedded, m_state, s, d, cfg.d_hidden),
+        MemoryRuleKind::MEMORA => memora_read_only(level_params, embedded, m_state, s, d, cfg.d_hidden),
+        MemoryRuleKind::LatticeOSR => lattice_read_only(level_params, embedded, m_state, s, d, cfg.m_slots),
+        MemoryRuleKind::Trellis => trellis_read_only(level_params, embedded, m_state, s, d, cfg.d_compress),
+        _ => delta_rule_read_only(level_params, embedded, m_state, s, d),
+    }
+}
+
+/// Read-only backward dispatch.
+fn read_only_backward_dispatch(
+    cfg: &MAGConfig,
+    level_params: &MemoryLevelParams,
+    frozen_m: &[f32],
+    q_mem: &[f32],
+    d_y: &[f32],
+    embedded: &[f32],
+    s: usize,
+    d: usize,
+) -> (MemoryLevelParams, Vec<f32>) {
+    match cfg.memory_rule {
+        MemoryRuleKind::Moneta => moneta_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_hidden),
+        MemoryRuleKind::YAAD => yaad_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_hidden),
+        MemoryRuleKind::MEMORA => memora_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_hidden),
+        MemoryRuleKind::LatticeOSR => lattice_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.m_slots),
+        MemoryRuleKind::Trellis => trellis_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_compress),
+        _ => delta_rule_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d),
+    }
+}
+
+/// Memory step dispatch. Returns (y, MemoryCache).
+fn step_dispatch(
+    cfg: &MAGConfig,
+    level_params: &MemoryLevelParams,
+    input: &[f32],
+    s: usize,
+    d: usize,
+    initial_m: Option<Vec<f32>>,
+) -> (Vec<f32>, MemoryCache) {
+    match cfg.memory_rule {
+        MemoryRuleKind::DeltaRule => {
+            let (y, c) = DeltaRule.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::Delta(c))
+        }
+        MemoryRuleKind::TitansLMM => {
+            let (y, c) = TitansLMM.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::Titans(c))
+        }
+        MemoryRuleKind::HebbianRule => {
+            let (y, c) = HebbianRule.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::Hebbian(c))
+        }
+        MemoryRuleKind::Moneta => {
+            let rule = Moneta { d_hidden: cfg.d_hidden, lp_p: cfg.lp_p, lambda_2: cfg.lambda_2 };
+            let (y, c) = rule.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::Moneta(c))
+        }
+        MemoryRuleKind::YAAD => {
+            let rule = YAAD { d_hidden: cfg.d_hidden, delta: cfg.delta, lambda_local: cfg.lambda_local, lambda_2: cfg.lambda_2 };
+            let (y, c) = rule.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::YAAD(c))
+        }
+        MemoryRuleKind::MEMORA => {
+            let rule = MEMORA { d_hidden: cfg.d_hidden };
+            let (y, c) = rule.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::MEMORA(c))
+        }
+        MemoryRuleKind::LatticeOSR => {
+            let rule = LatticeOSR { m_slots: cfg.m_slots };
+            let (y, c) = rule.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::Lattice(c))
+        }
+        MemoryRuleKind::Trellis => {
+            let rule = Trellis { d_k: cfg.d_compress, lambda_k: cfg.lambda_k, lambda_v: cfg.lambda_v };
+            let (y, c) = rule.step(level_params, input, s, d, initial_m);
+            (y, MemoryCache::Trellis(c))
+        }
+    }
+}
+
+/// Memory step_backward dispatch. Returns (level grads, d_input).
+fn step_backward_dispatch(
+    cfg: &MAGConfig,
+    level_params: &MemoryLevelParams,
+    cache: &MemoryCache,
+    d_y: &[f32],
+    input: &[f32],
+) -> (MemoryLevelParams, Vec<f32>) {
+    match cache {
+        MemoryCache::Delta(c) => DeltaRule.step_backward(level_params, c, d_y, input),
+        MemoryCache::Titans(c) => TitansLMM.step_backward(level_params, c, d_y, input),
+        MemoryCache::Hebbian(c) => HebbianRule.step_backward(level_params, c, d_y, input),
+        MemoryCache::Moneta(c) => {
+            let rule = Moneta { d_hidden: cfg.d_hidden, lp_p: cfg.lp_p, lambda_2: cfg.lambda_2 };
+            rule.step_backward(level_params, c, d_y, input)
+        }
+        MemoryCache::YAAD(c) => {
+            let rule = YAAD { d_hidden: cfg.d_hidden, delta: cfg.delta, lambda_local: cfg.lambda_local, lambda_2: cfg.lambda_2 };
+            rule.step_backward(level_params, c, d_y, input)
+        }
+        MemoryCache::MEMORA(c) => {
+            let rule = MEMORA { d_hidden: cfg.d_hidden };
+            rule.step_backward(level_params, c, d_y, input)
+        }
+        MemoryCache::Lattice(c) => {
+            let rule = LatticeOSR { m_slots: cfg.m_slots };
+            rule.step_backward(level_params, c, d_y, input)
+        }
+        MemoryCache::Trellis(c) => {
+            let rule = Trellis { d_k: cfg.d_compress, lambda_k: cfg.lambda_k, lambda_v: cfg.lambda_v };
+            rule.step_backward(level_params, c, d_y, input)
+        }
+    }
+}
+
+/// Get the initial memory state for read-only operations.
+/// For k=1 (no CMS), return zeros of the right size.
+fn initial_memory_state(cfg: &MAGConfig, d: usize) -> Vec<f32> {
+    match cfg.memory_rule {
+        MemoryRuleKind::Moneta | MemoryRuleKind::YAAD | MemoryRuleKind::MEMORA => {
+            vec![0.0f32; cfg.d_hidden * d + d * cfg.d_hidden]
+        }
+        MemoryRuleKind::LatticeOSR => {
+            vec![0.0f32; cfg.m_slots * d]
+        }
+        MemoryRuleKind::Trellis => {
+            vec![0.0f32; 2 * cfg.d_compress * d]
+        }
+        _ => vec![0.0f32; d * d],
+    }
+}
+
+/// MAC forward pass. Returns (loss, cache).
+pub fn mac_forward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    input_ids: &[usize],
+    target_ids: &[usize],
+) -> (f32, MACForwardCache) {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+    let s2 = 2 * s;
+
+    assert_eq!(d, nh * hd);
+    assert!(input_ids.len() >= s);
+    assert!(target_ids.len() >= s);
+    assert!(ws >= s2, "MAC requires window_size >= 2*seq_len for full causal attention on assembled input");
+
+    // Stage 1: Embedding lookup
+    let mut embedded = vec![0.0f32; s * d];
+    for t in 0..s {
+        let tok = input_ids[t];
+        assert!(tok < v, "mac_forward: input_ids[{t}]={tok} >= vocab_size {v}");
+        embedded[t * d..(t + 1) * d].copy_from_slice(&params.swa.w_embed[tok * d..(tok + 1) * d]);
+    }
+
+    // Stage 2: Read-only memory on embedded → h_t
+    let m_state = initial_memory_state(cfg, d);
+    let (h_t, q_mem_read) = read_only_dispatch(cfg, &params.levels[0], &embedded, &m_state, s, d);
+
+    // Stage 3: Assemble — concat(h_t, embedded) → (2s, d)
+    let mut assembled = vec![0.0f32; s2 * d];
+    assembled[..s * d].copy_from_slice(&h_t);
+    assembled[s * d..].copy_from_slice(&embedded);
+
+    // Stage 4: QKV projections on assembled
+    let mut w_q_t = vec![0.0f32; d * d];
+    let mut w_k_t = vec![0.0f32; d * d];
+    let mut w_v_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_q, &mut w_q_t, d, d);
+    transpose_f32(&params.swa.w_k, &mut w_k_t, d, d);
+    transpose_f32(&params.swa.w_v, &mut w_v_t, d, d);
+
+    let mut q = vec![0.0f32; s2 * d];
+    let mut k = vec![0.0f32; s2 * d];
+    let mut vv = vec![0.0f32; s2 * d];
+    matmul_f32(&assembled, &w_q_t, &mut q, s2, d, d);
+    matmul_f32(&assembled, &w_k_t, &mut k, s2, d, d);
+    matmul_f32(&assembled, &w_v_t, &mut vv, s2, d, d);
+
+    // Stage 5: Full causal attention on assembled (ws >= 2s)
+    let mut attn_out = vec![0.0f32; s2 * d];
+    let mut attn_weights = vec![0.0f32; nh * s2 * ws];
+    crate::dispatch::swa_forward_dispatch(&q, &k, &vv, &mut attn_out, &mut attn_weights, s2, nh, hd, ws);
+
+    // Stage 6: Extract y_t = attn_out[s*d..] → (s, d)
+    let y_t = attn_out[s * d..].to_vec();
+
+    // Stage 7: Memory step on y_t → reflective_y (updates M)
+    let (reflective_y, memory_cache) = step_dispatch(
+        cfg, &params.levels[0], &y_t, s, d, None,
+    );
+
+    // Stage 8: Reflective gate — output = y_t * sigmoid(reflective_y)
+    let mut reflective_gate = vec![0.0f32; s * d];
+    let mut gated_out = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        reflective_gate[i] = sigmoid_f32(reflective_y[i]);
+        gated_out[i] = y_t[i] * reflective_gate[i];
+    }
+
+    // Stage 9: Output projection
+    let mut w_o_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_o, &mut w_o_t, d, d);
+    let mut projected = vec![0.0f32; s * d];
+    matmul_f32(&gated_out, &w_o_t, &mut projected, s, d, d);
+
+    // Stage 10: Unembed
+    let mut logits = vec![0.0f32; s * v];
+    matmul_f32(&projected, &params.swa.w_unembed, &mut logits, s, d, v);
+
+    // Stage 11: Cross-entropy loss
+    let loss = cross_entropy_loss(&logits, target_ids, s, v);
+
+    let cache = MACForwardCache {
+        embedded, h_t, q_mem_read, frozen_m_read: m_state,
+        assembled, q, k, v: vv, attn_out, attn_weights,
+        y_t, memory_cache, reflective_y, reflective_gate, gated_out,
+        projected, logits,
+    };
+
+    (loss, cache)
+}
+
+/// MAC backward pass. Returns parameter gradients.
+pub fn mac_backward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    cache: &MACForwardCache,
+    input_ids: &[usize],
+    target_ids: &[usize],
+) -> MAGParams {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+    let s2 = 2 * s;
+
+    let mut grads = MAGParams::zeros_like(cfg);
+
+    // ── Stage 11: Cross-entropy gradient ─────────────────────────────
+    let mut d_logits = vec![0.0f32; s * v];
+    let count = (0..s)
+        .filter(|&t| target_ids.get(t).map_or(false, |&tok| tok < v))
+        .count() as f32;
+    if count > 0.0 {
+        for t in 0..s {
+            let target = match target_ids.get(t) {
+                Some(&tok) if tok < v => tok,
+                _ => continue,
+            };
+            let base = t * v;
+            let row = &cache.logits[base..base + v];
+            let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut sum_exp = 0.0f32;
+            for j in 0..v {
+                let e = (row[j] - max_val).exp();
+                d_logits[base + j] = e;
+                sum_exp += e;
+            }
+            for j in 0..v {
+                d_logits[base + j] /= sum_exp;
+            }
+            d_logits[base + target] -= 1.0;
+            for j in 0..v {
+                d_logits[base + j] /= count;
+            }
+        }
+    }
+
+    // ── Stage 10: Unembed backward ───────────────────────────────────
+    let mut w_unembed_t = vec![0.0f32; v * d];
+    transpose_f32(&params.swa.w_unembed, &mut w_unembed_t, d, v);
+    let mut d_projected = vec![0.0f32; s * d];
+    matmul_f32(&d_logits, &w_unembed_t, &mut d_projected, s, v, d);
+
+    let mut projected_t = vec![0.0f32; d * s];
+    transpose_f32(&cache.projected, &mut projected_t, s, d);
+    matmul_f32(&projected_t, &d_logits, &mut grads.swa.w_unembed, d, s, v);
+
+    // ── Stage 9: Output projection backward ──────────────────────────
+    let mut d_gated_out = vec![0.0f32; s * d];
+    matmul_f32(&d_projected, &params.swa.w_o, &mut d_gated_out, s, d, d);
+
+    let mut d_projected_t = vec![0.0f32; d * s];
+    transpose_f32(&d_projected, &mut d_projected_t, s, d);
+    matmul_f32(&d_projected_t, &cache.gated_out, &mut grads.swa.w_o, d, s, d);
+
+    // ── Stage 8: Reflective gate backward ────────────────────────────
+    // gated_out = y_t * reflective_gate
+    // d_y_t_gate = d_gated_out * reflective_gate
+    // d_reflective_gate = d_gated_out * y_t
+    let mut d_y_t_gate = vec![0.0f32; s * d];
+    let mut d_reflective_gate = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_y_t_gate[i] = d_gated_out[i] * cache.reflective_gate[i];
+        d_reflective_gate[i] = d_gated_out[i] * cache.y_t[i];
+    }
+
+    // reflective_gate = sigmoid(reflective_y) → d_reflective_y
+    let mut d_reflective_y = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_reflective_y[i] = d_reflective_gate[i]
+            * cache.reflective_gate[i]
+            * (1.0 - cache.reflective_gate[i]);
+    }
+
+    // ── Stage 7: Memory step backward (on y_t) ──────────────────────
+    let (mem_grads_step, d_y_t_mem) = step_backward_dispatch(
+        cfg, &params.levels[0], &cache.memory_cache, &d_reflective_y, &cache.y_t,
+    );
+
+    // Combine d_y_t from gate and memory
+    let mut d_y_t = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_y_t[i] = d_y_t_gate[i] + d_y_t_mem[i];
+    }
+
+    // ── Stage 6: Scatter d_y_t into d_attn_out at positions [s*d..] ─
+    let mut d_attn_out = vec![0.0f32; s2 * d];
+    d_attn_out[s * d..].copy_from_slice(&d_y_t);
+
+    // ── Stage 5: SWA backward (ws=2s) ────────────────────────────────
+    let mut d_q = vec![0.0f32; s2 * d];
+    let mut d_k = vec![0.0f32; s2 * d];
+    let mut d_v = vec![0.0f32; s2 * d];
+
+    crate::dispatch::swa_backward_dispatch(
+        &cache.q, &cache.k, &cache.v,
+        &cache.attn_weights, &d_attn_out,
+        &mut d_q, &mut d_k, &mut d_v,
+        s2, nh, hd, ws,
+    );
+
+    // ── Stage 4: QKV projection backward ─────────────────────────────
+    let mut d_assembled = vec![0.0f32; s2 * d];
+
+    crate::tensor::matmul_acc_f32(&d_q, &params.swa.w_q, &mut d_assembled, s2, d, d);
+    crate::tensor::matmul_acc_f32(&d_k, &params.swa.w_k, &mut d_assembled, s2, d, d);
+    crate::tensor::matmul_acc_f32(&d_v, &params.swa.w_v, &mut d_assembled, s2, d, d);
+
+    // Weight gradients: d_W = d_QKV^T @ assembled
+    let mut d_q_t = vec![0.0f32; d * s2];
+    transpose_f32(&d_q, &mut d_q_t, s2, d);
+    matmul_f32(&d_q_t, &cache.assembled, &mut grads.swa.w_q, d, s2, d);
+
+    let mut d_k_t = vec![0.0f32; d * s2];
+    transpose_f32(&d_k, &mut d_k_t, s2, d);
+    matmul_f32(&d_k_t, &cache.assembled, &mut grads.swa.w_k, d, s2, d);
+
+    let mut d_v_t = vec![0.0f32; d * s2];
+    transpose_f32(&d_v, &mut d_v_t, s2, d);
+    matmul_f32(&d_v_t, &cache.assembled, &mut grads.swa.w_v, d, s2, d);
+
+    // ── Stage 3: Split d_assembled → d_h_t + d_embedded_attn ─────────
+    let d_h_t = &d_assembled[..s * d];
+    let d_embedded_attn = &d_assembled[s * d..];
+
+    // ── Stage 2: Read-only backward → d_embedded_read + mem_grads_read
+    let (mem_grads_read, d_embedded_read) = read_only_backward_dispatch(
+        cfg, &params.levels[0], &cache.frozen_m_read, &cache.q_mem_read,
+        d_h_t, &cache.embedded, s, d,
+    );
+
+    // Combine memory grads from both step and read paths
+    grads.levels[0].accumulate(&mem_grads_step);
+    grads.levels[0].accumulate(&mem_grads_read);
+
+    // Combine d_embedded from attn and read paths
+    let mut d_embedded = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_embedded[i] = d_embedded_attn[i] + d_embedded_read[i];
+    }
+
+    // ── Stage 1: Embedding scatter-add ───────────────────────────────
+    for t in 0..s {
+        let tok = input_ids[t];
+        for dd in 0..d {
+            grads.swa.w_embed[tok * d + dd] += d_embedded[t * d + dd];
+        }
+    }
+
+    grads
+}
+
+// ── CMS MAC ─────────────────────────────────────────────────────────
+
+/// Cache for CMS MAC forward pass.
+pub struct CMSMACForwardCache {
+    pub embedded: Vec<f32>,
+    // Per-level read-only context
+    pub read_caches: Vec<ReadOnlyCacheLevel>,
+    pub h_t_combined: Vec<f32>,
+    // Assembled and attention
+    pub assembled: Vec<f32>,
+    pub q: Vec<f32>,
+    pub k: Vec<f32>,
+    pub v: Vec<f32>,
+    pub attn_out: Vec<f32>,
+    pub attn_weights: Vec<f32>,
+    pub y_t: Vec<f32>,
+    // Per-level step (active only)
+    pub step_caches: Vec<Option<MemoryCache>>,
+    pub reflective_per_level: Vec<Option<Vec<f32>>>,
+    pub reflective_y_combined: Vec<f32>,
+    pub reflective_gate: Vec<f32>,
+    pub gated_out: Vec<f32>,
+    pub projected: Vec<f32>,
+    pub logits: Vec<f32>,
+    pub pulse: Pulse,
+}
+
+/// Per-level read-only cache for CMS MAC.
+pub struct ReadOnlyCacheLevel {
+    pub q_mem: Vec<f32>,
+    pub frozen_m: Vec<f32>,
+}
+
+/// Extract final memory state from cache for context persistence (MAC-specific).
+fn persist_mac_memory(
+    cfg: &MAGConfig,
+    cache: &MemoryCache,
+    s: usize,
+    d: usize,
+    context_mem: &mut Vec<f32>,
+) {
+    crate::mal::persist_memory_state(cfg, cache, s, d, context_mem);
+}
+
+/// CMS MAC forward pass.
+pub fn cms_mac_forward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    input_ids: &[usize],
+    target_ids: &[usize],
+    pulse: &Pulse,
+    context: &mut ContextState,
+) -> (f32, CMSMACForwardCache) {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+    let s2 = 2 * s;
+
+    assert_eq!(d, nh * hd);
+    assert!(input_ids.len() >= s);
+    assert!(target_ids.len() >= s);
+    assert!(ws >= s2, "CMS MAC requires window_size >= 2*seq_len");
+    assert_eq!(pulse.active_levels.len(), cfg.k);
+    assert_eq!(context.memory.len(), cfg.k);
+
+    // Stage 1: Embedding lookup
+    let mut embedded = vec![0.0f32; s * d];
+    for t in 0..s {
+        let tok = input_ids[t];
+        assert!(tok < v, "cms_mac_forward: input_ids[{t}]={tok} >= vocab_size {v}");
+        embedded[t * d..(t + 1) * d].copy_from_slice(&params.swa.w_embed[tok * d..(tok + 1) * d]);
+    }
+
+    // Stage 2: Per-level read-only → h_t per level
+    let mut read_caches = Vec::with_capacity(cfg.k);
+    let mut h_t_per_level: Vec<Vec<f32>> = Vec::with_capacity(cfg.k);
+
+    for level in 0..cfg.k {
+        let frozen_ref = &context.memory[level];
+        let (h_level, q_mem) = read_only_dispatch(
+            cfg, &params.levels[level], &embedded, frozen_ref, s, d,
+        );
+        h_t_per_level.push(h_level);
+        read_caches.push(ReadOnlyCacheLevel {
+            q_mem,
+            frozen_m: frozen_ref.clone(),
+        });
+    }
+
+    // Combine h_t with 1/sqrt(k) for k>2
+    let mut h_t_combined = vec![0.0f32; s * d];
+    for h in &h_t_per_level {
+        for i in 0..(s * d) {
+            h_t_combined[i] += h[i];
+        }
+    }
+    if cfg.k > 2 {
+        let scale = 1.0 / (cfg.k as f32).sqrt();
+        for i in 0..(s * d) {
+            h_t_combined[i] *= scale;
+        }
+    }
+
+    // Stage 3: Assemble
+    let mut assembled = vec![0.0f32; s2 * d];
+    assembled[..s * d].copy_from_slice(&h_t_combined);
+    assembled[s * d..].copy_from_slice(&embedded);
+
+    // Stage 4: QKV projections on assembled
+    let mut w_q_t = vec![0.0f32; d * d];
+    let mut w_k_t = vec![0.0f32; d * d];
+    let mut w_v_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_q, &mut w_q_t, d, d);
+    transpose_f32(&params.swa.w_k, &mut w_k_t, d, d);
+    transpose_f32(&params.swa.w_v, &mut w_v_t, d, d);
+
+    let mut q = vec![0.0f32; s2 * d];
+    let mut k = vec![0.0f32; s2 * d];
+    let mut vv = vec![0.0f32; s2 * d];
+    matmul_f32(&assembled, &w_q_t, &mut q, s2, d, d);
+    matmul_f32(&assembled, &w_k_t, &mut k, s2, d, d);
+    matmul_f32(&assembled, &w_v_t, &mut vv, s2, d, d);
+
+    // Stage 5: Full causal attention
+    let mut attn_out = vec![0.0f32; s2 * d];
+    let mut attn_weights = vec![0.0f32; nh * s2 * ws];
+    crate::dispatch::swa_forward_dispatch(&q, &k, &vv, &mut attn_out, &mut attn_weights, s2, nh, hd, ws);
+
+    // Stage 6: Extract y_t
+    let y_t = attn_out[s * d..].to_vec();
+
+    // Stage 7: Per-level reflective memory step (active only)
+    let mut step_caches: Vec<Option<MemoryCache>> = Vec::with_capacity(cfg.k);
+    let mut reflective_per_level: Vec<Option<Vec<f32>>> = Vec::with_capacity(cfg.k);
+
+    for level in 0..cfg.k {
+        if pulse.active_levels[level] {
+            let initial_m = Some(std::mem::take(&mut context.memory[level]));
+            let (refl_y, mem_cache) = step_dispatch(
+                cfg, &params.levels[level], &y_t, s, d, initial_m,
+            );
+            persist_mac_memory(cfg, &mem_cache, s, d, &mut context.memory[level]);
+            reflective_per_level.push(Some(refl_y));
+            step_caches.push(Some(mem_cache));
+        } else {
+            // Frozen levels: no reflective signal (read-only only contributes h_t)
+            reflective_per_level.push(None);
+            step_caches.push(None);
+        }
+    }
+
+    // Combine reflective outputs (active levels only)
+    let mut reflective_y_combined = vec![0.0f32; s * d];
+    let mut active_count = 0usize;
+    for refl in &reflective_per_level {
+        if let Some(r) = refl {
+            for i in 0..(s * d) {
+                reflective_y_combined[i] += r[i];
+            }
+            active_count += 1;
+        }
+    }
+    // Normalize if multiple active levels contribute to reflective signal
+    if active_count > 2 {
+        let scale = 1.0 / (active_count as f32).sqrt();
+        for i in 0..(s * d) {
+            reflective_y_combined[i] *= scale;
+        }
+    }
+
+    // Stage 8: Reflective gate
+    let mut reflective_gate = vec![0.0f32; s * d];
+    let mut gated_out = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        reflective_gate[i] = sigmoid_f32(reflective_y_combined[i]);
+        gated_out[i] = y_t[i] * reflective_gate[i];
+    }
+
+    // Stage 9: Output projection
+    let mut w_o_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_o, &mut w_o_t, d, d);
+    let mut projected = vec![0.0f32; s * d];
+    matmul_f32(&gated_out, &w_o_t, &mut projected, s, d, d);
+
+    // Stage 10: Unembed
+    let mut logits = vec![0.0f32; s * v];
+    matmul_f32(&projected, &params.swa.w_unembed, &mut logits, s, d, v);
+
+    // Stage 11: Cross-entropy loss
+    let loss = cross_entropy_loss(&logits, target_ids, s, v);
+
+    let cache = CMSMACForwardCache {
+        embedded, read_caches, h_t_combined,
+        assembled, q, k, v: vv, attn_out, attn_weights, y_t,
+        step_caches, reflective_per_level, reflective_y_combined,
+        reflective_gate, gated_out,
+        projected, logits,
+        pulse: pulse.clone(),
+    };
+
+    (loss, cache)
+}
+
+/// CMS MAC backward pass.
+pub fn cms_mac_backward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    cache: &CMSMACForwardCache,
+    input_ids: &[usize],
+    target_ids: &[usize],
+    error_buffers: &mut [ErrorBuffer],
+) -> MAGParams {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+    let s2 = 2 * s;
+
+    let mut grads = MAGParams::zeros_like(cfg);
+
+    // ── Stage 11: Cross-entropy gradient ─────────────────────────────
+    let mut d_logits = vec![0.0f32; s * v];
+    let count = (0..s)
+        .filter(|&t| target_ids.get(t).map_or(false, |&tok| tok < v))
+        .count() as f32;
+    if count > 0.0 {
+        for t in 0..s {
+            let target = match target_ids.get(t) {
+                Some(&tok) if tok < v => tok,
+                _ => continue,
+            };
+            let base = t * v;
+            let row = &cache.logits[base..base + v];
+            let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut sum_exp = 0.0f32;
+            for j in 0..v {
+                let e = (row[j] - max_val).exp();
+                d_logits[base + j] = e;
+                sum_exp += e;
+            }
+            for j in 0..v {
+                d_logits[base + j] /= sum_exp;
+            }
+            d_logits[base + target] -= 1.0;
+            for j in 0..v {
+                d_logits[base + j] /= count;
+            }
+        }
+    }
+
+    // ── Stage 10: Unembed backward ───────────────────────────────────
+    let mut w_unembed_t = vec![0.0f32; v * d];
+    transpose_f32(&params.swa.w_unembed, &mut w_unembed_t, d, v);
+    let mut d_projected = vec![0.0f32; s * d];
+    matmul_f32(&d_logits, &w_unembed_t, &mut d_projected, s, v, d);
+
+    let mut projected_t = vec![0.0f32; d * s];
+    transpose_f32(&cache.projected, &mut projected_t, s, d);
+    matmul_f32(&projected_t, &d_logits, &mut grads.swa.w_unembed, d, s, v);
+
+    // ── Stage 9: Output projection backward ──────────────────────────
+    let mut d_gated_out = vec![0.0f32; s * d];
+    matmul_f32(&d_projected, &params.swa.w_o, &mut d_gated_out, s, d, d);
+
+    let mut d_projected_t = vec![0.0f32; d * s];
+    transpose_f32(&d_projected, &mut d_projected_t, s, d);
+    matmul_f32(&d_projected_t, &cache.gated_out, &mut grads.swa.w_o, d, s, d);
+
+    // ── Stage 8: Reflective gate backward ────────────────────────────
+    let mut d_y_t_gate = vec![0.0f32; s * d];
+    let mut d_reflective_gate = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_y_t_gate[i] = d_gated_out[i] * cache.reflective_gate[i];
+        d_reflective_gate[i] = d_gated_out[i] * cache.y_t[i];
+    }
+
+    let mut d_reflective_y_combined = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_reflective_y_combined[i] = d_reflective_gate[i]
+            * cache.reflective_gate[i]
+            * (1.0 - cache.reflective_gate[i]);
+    }
+
+    // Normalize reflective gradient if multiple active levels
+    let active_count = cache.step_caches.iter().filter(|c| c.is_some()).count();
+    if active_count > 2 {
+        let scale = 1.0 / (active_count as f32).sqrt();
+        for i in 0..(s * d) {
+            d_reflective_y_combined[i] *= scale;
+        }
+    }
+
+    // ── Stage 7: Per-level step backward (active levels only) ────────
+    let mut d_y_t_mem_total = vec![0.0f32; s * d];
+    for level in 0..cfg.k {
+        if let Some(ref step_cache) = cache.step_caches[level] {
+            let (mem_grads, d_y_t_mem) = step_backward_dispatch(
+                cfg, &params.levels[level], step_cache, &d_reflective_y_combined, &cache.y_t,
+            );
+            grads.levels[level].accumulate(&mem_grads);
+            for i in 0..(s * d) {
+                d_y_t_mem_total[i] += d_y_t_mem[i];
+            }
+        }
+    }
+
+    // Combine d_y_t
+    let mut d_y_t = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_y_t[i] = d_y_t_gate[i] + d_y_t_mem_total[i];
+    }
+
+    // ── Stage 6: Scatter d_y_t into d_attn_out ──────────────────────
+    let mut d_attn_out = vec![0.0f32; s2 * d];
+    d_attn_out[s * d..].copy_from_slice(&d_y_t);
+
+    // ── Stage 5: SWA backward ────────────────────────────────────────
+    let mut d_q = vec![0.0f32; s2 * d];
+    let mut d_k = vec![0.0f32; s2 * d];
+    let mut d_v = vec![0.0f32; s2 * d];
+
+    crate::dispatch::swa_backward_dispatch(
+        &cache.q, &cache.k, &cache.v,
+        &cache.attn_weights, &d_attn_out,
+        &mut d_q, &mut d_k, &mut d_v,
+        s2, nh, hd, ws,
+    );
+
+    // ── Stage 4: QKV projection backward ─────────────────────────────
+    let mut d_assembled = vec![0.0f32; s2 * d];
+
+    crate::tensor::matmul_acc_f32(&d_q, &params.swa.w_q, &mut d_assembled, s2, d, d);
+    crate::tensor::matmul_acc_f32(&d_k, &params.swa.w_k, &mut d_assembled, s2, d, d);
+    crate::tensor::matmul_acc_f32(&d_v, &params.swa.w_v, &mut d_assembled, s2, d, d);
+
+    let mut d_q_t = vec![0.0f32; d * s2];
+    transpose_f32(&d_q, &mut d_q_t, s2, d);
+    matmul_f32(&d_q_t, &cache.assembled, &mut grads.swa.w_q, d, s2, d);
+
+    let mut d_k_t = vec![0.0f32; d * s2];
+    transpose_f32(&d_k, &mut d_k_t, s2, d);
+    matmul_f32(&d_k_t, &cache.assembled, &mut grads.swa.w_k, d, s2, d);
+
+    let mut d_v_t = vec![0.0f32; d * s2];
+    transpose_f32(&d_v, &mut d_v_t, s2, d);
+    matmul_f32(&d_v_t, &cache.assembled, &mut grads.swa.w_v, d, s2, d);
+
+    // ── Stage 3: Split d_assembled ───────────────────────────────────
+    let d_h_t_combined = &d_assembled[..s * d];
+    let d_embedded_attn = &d_assembled[s * d..];
+
+    // 1/sqrt(k) chain rule for h_t normalization
+    let mut d_h_t_per_level = d_h_t_combined.to_vec();
+    if cfg.k > 2 {
+        let scale = 1.0 / (cfg.k as f32).sqrt();
+        for i in 0..(s * d) {
+            d_h_t_per_level[i] *= scale;
+        }
+    }
+
+    // ── Stage 2: Per-level read-only backward ────────────────────────
+    let mut d_embedded_read_total = vec![0.0f32; s * d];
+    for level in 0..cfg.k {
+        let rc = &cache.read_caches[level];
+        let (mem_grads_read, d_embedded_read) = read_only_backward_dispatch(
+            cfg, &params.levels[level], &rc.frozen_m, &rc.q_mem,
+            &d_h_t_per_level, &cache.embedded, s, d,
+        );
+        // Read-only grads go to error buffers for frozen levels, direct grads for active
+        if cache.pulse.active_levels[level] {
+            grads.levels[level].accumulate(&mem_grads_read);
+        } else {
+            error_buffers[level].accumulate(&mem_grads_read);
+        }
+        for i in 0..(s * d) {
+            d_embedded_read_total[i] += d_embedded_read[i];
+        }
+    }
+
+    // Combine d_embedded
+    let mut d_embedded = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        d_embedded[i] = d_embedded_attn[i] + d_embedded_read_total[i];
+    }
+
+    // ── Stage 1: Embedding scatter-add ───────────────────────────────
+    for t in 0..s {
+        let tok = input_ids[t];
+        for dd in 0..d {
+            grads.swa.w_embed[tok * d + dd] += d_embedded[t * d + dd];
+        }
+    }
+
+    grads
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{MAGConfig, MAGParams};
+
+    fn test_config() -> MAGConfig {
+        MAGConfig::mac_test_config()
+    }
+
+    fn make_test_data(cfg: &MAGConfig) -> (Vec<usize>, Vec<usize>) {
+        let input_ids: Vec<usize> = (0..cfg.swa.seq_len).collect();
+        let target_ids: Vec<usize> = (1..=cfg.swa.seq_len)
+            .map(|t| t % cfg.swa.vocab_size)
+            .collect();
+        (input_ids, target_ids)
+    }
+
+    #[test]
+    fn test_mac_forward_finite_loss() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (loss, _cache) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+        assert!(loss.is_finite(), "MAC loss not finite: {loss}");
+        assert!(loss > 0.0, "MAC loss should be positive: {loss}");
+        assert!(loss < 20.0, "MAC loss too high: {loss}");
+    }
+
+    #[test]
+    fn test_mac_forward_deterministic() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (loss1, _) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+        let (loss2, _) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+        assert_eq!(loss1, loss2, "MAC forward should be deterministic");
+    }
+
+    #[test]
+    fn test_mac_backward_finite() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (_loss, cache) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+        let grads = mac_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+
+        for (name, g) in [
+            ("w_q", &grads.swa.w_q), ("w_k", &grads.swa.w_k),
+            ("w_v", &grads.swa.w_v), ("w_o", &grads.swa.w_o),
+            ("w_unembed", &grads.swa.w_unembed), ("w_embed", &grads.swa.w_embed),
+            ("w_k_mem", &grads.levels[0].w_k_mem),
+        ] {
+            for (i, &val) in g.iter().enumerate() {
+                assert!(val.is_finite(), "mac grad_{name}[{i}] not finite: {val}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_mac_backward_nonzero() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (_loss, cache) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+        let grads = mac_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+
+        // w_k_mem gradient is attenuated through read_only + concat + attn + step +
+        // reflective gate at init, so use a relaxed threshold (1e-12).
+        for (name, g) in [
+            ("w_q", &grads.swa.w_q), ("w_o", &grads.swa.w_o),
+            ("w_k_mem", &grads.levels[0].w_k_mem),
+        ] {
+            let max_abs = g.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+            assert!(max_abs > 1e-12, "mac grad_{name} all zeros (max_abs={max_abs})");
+        }
+    }
+
+    #[test]
+    fn test_mac_reflective_gate() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (_loss, cache) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+
+        // Gate should be non-trivial (not all 0.5 — memory actually does something)
+        let gate_sum: f32 = cache.reflective_gate.iter().sum();
+        let gate_mean = gate_sum / cache.reflective_gate.len() as f32;
+        // With zero-init memory, read_only returns zeros, so reflective gate ≈ 0.5
+        // But memory.step updates M, so reflective_y should be non-trivial
+        for &g in &cache.reflective_gate {
+            assert!(g > 0.0 && g < 1.0, "reflective_gate value {g} not in (0,1)");
+        }
+        eprintln!("MAC reflective gate mean: {gate_mean:.4}");
+    }
+}

--- a/core/src/mal.rs
+++ b/core/src/mal.rs
@@ -1,0 +1,824 @@
+/// MAL (Memory As Layer) composition.
+///
+/// Architecture:
+///   embed → memory.step(embedded) → m_t → QKV(m_t) → SWA(m_t) → output proj → unembed → loss
+///
+/// Simplest composition: memory preprocesses input, attention processes memory output.
+/// No sigmoid gate — m_t IS the attention input. Information bottleneck by design.
+
+use crate::tensor::{matmul_f32, transpose_f32, cross_entropy_loss};
+use crate::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use crate::delta_rule::{MemoryRule, DeltaRule, delta_rule_read_only, delta_rule_read_only_backward};
+use crate::titans_lmm::TitansLMM;
+use crate::hebbian_rule::HebbianRule;
+use crate::moneta::{Moneta, moneta_read_only, moneta_read_only_backward};
+use crate::yaad::{YAAD, yaad_read_only, yaad_read_only_backward};
+use crate::memora::{MEMORA, memora_read_only, memora_read_only_backward};
+use crate::lattice_osr::{LatticeOSR, lattice_read_only, lattice_read_only_backward};
+use crate::trellis::{Trellis, trellis_read_only, trellis_read_only_backward};
+use crate::conductor::{Pulse, ContextState, ErrorBuffer};
+use crate::mag::MemoryCache;
+
+/// Cache for MAL forward pass.
+pub struct MALForwardCache {
+    pub embedded: Vec<f32>,
+    pub m_t: Vec<f32>,          // memory output: [seq_len, d]
+    pub attn_input: Vec<f32>,   // m_t + embedded (residual for bootstrapping)
+    pub memory_cache: MemoryCache,
+    pub q: Vec<f32>,            // computed from attn_input
+    pub k: Vec<f32>,
+    pub v: Vec<f32>,
+    pub attn_out: Vec<f32>,
+    pub attn_weights: Vec<f32>,
+    pub projected: Vec<f32>,
+    pub logits: Vec<f32>,
+}
+
+/// Dispatch memory step for MAL. Returns (y, MemoryCache).
+fn dispatch_memory_step(
+    cfg: &MAGConfig,
+    level_params: &crate::model::MemoryLevelParams,
+    embedded: &[f32],
+    s: usize,
+    d: usize,
+    initial_m: Option<Vec<f32>>,
+) -> (Vec<f32>, MemoryCache) {
+    match cfg.memory_rule {
+        MemoryRuleKind::DeltaRule => {
+            let (y, cache) = DeltaRule.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::Delta(cache))
+        }
+        MemoryRuleKind::TitansLMM => {
+            let (y, cache) = TitansLMM.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::Titans(cache))
+        }
+        MemoryRuleKind::HebbianRule => {
+            let (y, cache) = HebbianRule.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::Hebbian(cache))
+        }
+        MemoryRuleKind::Moneta => {
+            let rule = Moneta { d_hidden: cfg.d_hidden, lp_p: cfg.lp_p, lambda_2: cfg.lambda_2 };
+            let (y, cache) = rule.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::Moneta(cache))
+        }
+        MemoryRuleKind::YAAD => {
+            let rule = YAAD { d_hidden: cfg.d_hidden, delta: cfg.delta, lambda_local: cfg.lambda_local, lambda_2: cfg.lambda_2 };
+            let (y, cache) = rule.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::YAAD(cache))
+        }
+        MemoryRuleKind::MEMORA => {
+            let rule = MEMORA { d_hidden: cfg.d_hidden };
+            let (y, cache) = rule.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::MEMORA(cache))
+        }
+        MemoryRuleKind::LatticeOSR => {
+            let rule = LatticeOSR { m_slots: cfg.m_slots };
+            let (y, cache) = rule.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::Lattice(cache))
+        }
+        MemoryRuleKind::Trellis => {
+            let rule = Trellis { d_k: cfg.d_compress, lambda_k: cfg.lambda_k, lambda_v: cfg.lambda_v };
+            let (y, cache) = rule.step(level_params, embedded, s, d, initial_m);
+            (y, MemoryCache::Trellis(cache))
+        }
+    }
+}
+
+/// Dispatch memory step_backward. Returns (level param grads, d_embedded).
+fn dispatch_memory_backward(
+    cfg: &MAGConfig,
+    level_params: &crate::model::MemoryLevelParams,
+    cache: &MemoryCache,
+    d_y: &[f32],
+    embedded: &[f32],
+) -> (crate::model::MemoryLevelParams, Vec<f32>) {
+    match cache {
+        MemoryCache::Delta(c) => DeltaRule.step_backward(level_params, c, d_y, embedded),
+        MemoryCache::Titans(c) => TitansLMM.step_backward(level_params, c, d_y, embedded),
+        MemoryCache::Hebbian(c) => HebbianRule.step_backward(level_params, c, d_y, embedded),
+        MemoryCache::Moneta(c) => {
+            let rule = Moneta { d_hidden: cfg.d_hidden, lp_p: cfg.lp_p, lambda_2: cfg.lambda_2 };
+            rule.step_backward(level_params, c, d_y, embedded)
+        }
+        MemoryCache::YAAD(c) => {
+            let rule = YAAD { d_hidden: cfg.d_hidden, delta: cfg.delta, lambda_local: cfg.lambda_local, lambda_2: cfg.lambda_2 };
+            rule.step_backward(level_params, c, d_y, embedded)
+        }
+        MemoryCache::MEMORA(c) => {
+            let rule = MEMORA { d_hidden: cfg.d_hidden };
+            rule.step_backward(level_params, c, d_y, embedded)
+        }
+        MemoryCache::Lattice(c) => {
+            let rule = LatticeOSR { m_slots: cfg.m_slots };
+            rule.step_backward(level_params, c, d_y, embedded)
+        }
+        MemoryCache::Trellis(c) => {
+            let rule = Trellis { d_k: cfg.d_compress, lambda_k: cfg.lambda_k, lambda_v: cfg.lambda_v };
+            rule.step_backward(level_params, c, d_y, embedded)
+        }
+    }
+}
+
+/// MAL forward pass. Returns (loss, cache).
+pub fn mal_forward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    input_ids: &[usize],
+    target_ids: &[usize],
+) -> (f32, MALForwardCache) {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+
+    assert_eq!(d, nh * hd);
+    assert!(input_ids.len() >= s);
+    assert!(target_ids.len() >= s);
+
+    // Stage 1: Embedding lookup
+    let mut embedded = vec![0.0f32; s * d];
+    for t in 0..s {
+        let tok = input_ids[t];
+        assert!(tok < v, "mal_forward: input_ids[{t}]={tok} >= vocab_size {v}");
+        embedded[t * d..(t + 1) * d].copy_from_slice(&params.swa.w_embed[tok * d..(tok + 1) * d]);
+    }
+
+    // Stage 2: Memory step on embedded → m_t
+    let (m_t, memory_cache) = dispatch_memory_step(cfg, &params.levels[0], &embedded, s, d, None);
+
+    // Stage 2.5: Residual — attn_input = m_t + embedded
+    // This breaks the bootstrapping deadlock: at init m_t ≈ 0, so attention sees embedded.
+    // As memory learns, m_t adds useful context to the raw input.
+    let mut attn_input = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        attn_input[i] = m_t[i] + embedded[i];
+    }
+
+    // Stage 3: QKV projections on attn_input (m_t + embedded)
+    let mut w_q_t = vec![0.0f32; d * d];
+    let mut w_k_t = vec![0.0f32; d * d];
+    let mut w_v_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_q, &mut w_q_t, d, d);
+    transpose_f32(&params.swa.w_k, &mut w_k_t, d, d);
+    transpose_f32(&params.swa.w_v, &mut w_v_t, d, d);
+
+    let mut q = vec![0.0f32; s * d];
+    let mut k = vec![0.0f32; s * d];
+    let mut vv = vec![0.0f32; s * d];
+    matmul_f32(&attn_input, &w_q_t, &mut q, s, d, d);
+    matmul_f32(&attn_input, &w_k_t, &mut k, s, d, d);
+    matmul_f32(&attn_input, &w_v_t, &mut vv, s, d, d);
+
+    // Stage 4: SWA Attention
+    let mut attn_out = vec![0.0f32; s * d];
+    let mut attn_weights = vec![0.0f32; nh * s * ws];
+    crate::dispatch::swa_forward_dispatch(&q, &k, &vv, &mut attn_out, &mut attn_weights, s, nh, hd, ws);
+
+    // Stage 5: Output projection
+    let mut w_o_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_o, &mut w_o_t, d, d);
+    let mut projected = vec![0.0f32; s * d];
+    matmul_f32(&attn_out, &w_o_t, &mut projected, s, d, d);
+
+    // Stage 6: Unembed
+    let mut logits = vec![0.0f32; s * v];
+    matmul_f32(&projected, &params.swa.w_unembed, &mut logits, s, d, v);
+
+    // Stage 7: Cross-entropy loss
+    let loss = cross_entropy_loss(&logits, target_ids, s, v);
+
+    let cache = MALForwardCache {
+        embedded, m_t, attn_input, memory_cache,
+        q, k, v: vv, attn_out, attn_weights,
+        projected, logits,
+    };
+
+    (loss, cache)
+}
+
+/// MAL backward pass. Returns parameter gradients.
+pub fn mal_backward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    cache: &MALForwardCache,
+    input_ids: &[usize],
+    target_ids: &[usize],
+) -> MAGParams {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+
+    let mut grads = MAGParams::zeros_like(cfg);
+
+    // ── Stage 7: Cross-entropy gradient ──────────────────────────────
+    let mut d_logits = vec![0.0f32; s * v];
+    let count = (0..s)
+        .filter(|&t| target_ids.get(t).map_or(false, |&tok| tok < v))
+        .count() as f32;
+    if count > 0.0 {
+        for t in 0..s {
+            let target = match target_ids.get(t) {
+                Some(&tok) if tok < v => tok,
+                _ => continue,
+            };
+            let base = t * v;
+            let row = &cache.logits[base..base + v];
+            let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut sum_exp = 0.0f32;
+            for j in 0..v {
+                let e = (row[j] - max_val).exp();
+                d_logits[base + j] = e;
+                sum_exp += e;
+            }
+            for j in 0..v {
+                d_logits[base + j] /= sum_exp;
+            }
+            d_logits[base + target] -= 1.0;
+            for j in 0..v {
+                d_logits[base + j] /= count;
+            }
+        }
+    }
+
+    // ── Stage 6: Unembed backward ────────────────────────────────────
+    let mut w_unembed_t = vec![0.0f32; v * d];
+    transpose_f32(&params.swa.w_unembed, &mut w_unembed_t, d, v);
+    let mut d_projected = vec![0.0f32; s * d];
+    matmul_f32(&d_logits, &w_unembed_t, &mut d_projected, s, v, d);
+
+    let mut projected_t = vec![0.0f32; d * s];
+    transpose_f32(&cache.projected, &mut projected_t, s, d);
+    matmul_f32(&projected_t, &d_logits, &mut grads.swa.w_unembed, d, s, v);
+
+    // ── Stage 5: Output projection backward ──────────────────────────
+    let mut d_attn_out = vec![0.0f32; s * d];
+    matmul_f32(&d_projected, &params.swa.w_o, &mut d_attn_out, s, d, d);
+
+    let mut d_projected_t = vec![0.0f32; d * s];
+    transpose_f32(&d_projected, &mut d_projected_t, s, d);
+    matmul_f32(&d_projected_t, &cache.attn_out, &mut grads.swa.w_o, d, s, d);
+
+    // ── Stage 4: SWA Attention backward ─────────────────────────────
+    let mut d_q = vec![0.0f32; s * d];
+    let mut d_k = vec![0.0f32; s * d];
+    let mut d_v = vec![0.0f32; s * d];
+
+    crate::dispatch::swa_backward_dispatch(
+        &cache.q, &cache.k, &cache.v,
+        &cache.attn_weights, &d_attn_out,
+        &mut d_q, &mut d_k, &mut d_v,
+        s, nh, hd, ws,
+    );
+
+    // ── Stage 3: QKV projection backward (inputs are attn_input = m_t + embedded) ─
+    let mut d_attn_input = vec![0.0f32; s * d];
+
+    crate::tensor::matmul_acc_f32(&d_q, &params.swa.w_q, &mut d_attn_input, s, d, d);
+    crate::tensor::matmul_acc_f32(&d_k, &params.swa.w_k, &mut d_attn_input, s, d, d);
+    crate::tensor::matmul_acc_f32(&d_v, &params.swa.w_v, &mut d_attn_input, s, d, d);
+
+    // Weight gradients: d_W = d_QKV^T @ attn_input
+    let mut d_q_t = vec![0.0f32; d * s];
+    transpose_f32(&d_q, &mut d_q_t, s, d);
+    matmul_f32(&d_q_t, &cache.attn_input, &mut grads.swa.w_q, d, s, d);
+
+    let mut d_k_t = vec![0.0f32; d * s];
+    transpose_f32(&d_k, &mut d_k_t, s, d);
+    matmul_f32(&d_k_t, &cache.attn_input, &mut grads.swa.w_k, d, s, d);
+
+    let mut d_v_t = vec![0.0f32; d * s];
+    transpose_f32(&d_v, &mut d_v_t, s, d);
+    matmul_f32(&d_v_t, &cache.attn_input, &mut grads.swa.w_v, d, s, d);
+
+    // ── Stage 2.5: Residual backward (attn_input = m_t + embedded) ──
+    // d_m_t = d_attn_input (gradient flows to memory)
+    // d_embedded_res = d_attn_input (gradient flows to embedding via residual)
+    let d_m_t = d_attn_input.clone();
+
+    // ── Stage 2: Memory backward ────────────────────────────────────
+    let (mem_grads, d_embedded_mem) = dispatch_memory_backward(
+        cfg, &params.levels[0], &cache.memory_cache, &d_m_t, &cache.embedded,
+    );
+    grads.levels[0].accumulate(&mem_grads);
+
+    // ── Stage 1: Embedding scatter-add (residual + memory paths) ────
+    for t in 0..s {
+        let tok = input_ids[t];
+        for dd in 0..d {
+            // Residual path: d_attn_input flows directly to embedding
+            // Memory path: d_embedded_mem from memory backward
+            grads.swa.w_embed[tok * d + dd] += d_attn_input[t * d + dd] + d_embedded_mem[t * d + dd];
+        }
+    }
+
+    grads
+}
+
+// ── CMS MAL ─────────────────────────────────────────────────────────
+
+/// Cache for CMS MAL forward pass.
+pub struct CMSMALForwardCache {
+    pub embedded: Vec<f32>,
+    pub memory_caches: Vec<Option<MemoryCache>>,
+    pub q_mem_per_level: Vec<Option<Vec<f32>>>,
+    pub frozen_memories: Vec<Option<Vec<f32>>>,
+    pub y_per_level: Vec<Vec<f32>>,
+    pub m_t_combined: Vec<f32>,
+    pub attn_input: Vec<f32>,   // m_t_combined + embedded (residual)
+    pub q: Vec<f32>,
+    pub k: Vec<f32>,
+    pub v: Vec<f32>,
+    pub attn_out: Vec<f32>,
+    pub attn_weights: Vec<f32>,
+    pub projected: Vec<f32>,
+    pub logits: Vec<f32>,
+    pub pulse: Pulse,
+}
+
+/// Extract final memory state from cache and persist to context.
+pub fn persist_memory_state(
+    _cfg: &MAGConfig,
+    cache: &MemoryCache,
+    s: usize,
+    d: usize,
+    context_mem: &mut Vec<f32>,
+) {
+    match cache {
+        MemoryCache::Delta(c) => {
+            let start = s * d * d;
+            *context_mem = c.m_states[start..start + d * d].to_vec();
+        }
+        MemoryCache::Titans(c) => {
+            let start = s * d * d;
+            *context_mem = c.m_states[start..start + d * d].to_vec();
+        }
+        MemoryCache::Hebbian(c) => {
+            let start = s * d * d;
+            *context_mem = c.m_states[start..start + d * d].to_vec();
+        }
+        MemoryCache::Moneta(c) => {
+            let dh = c.d_hidden;
+            let w1_size = dh * d;
+            let w2_size = d * dh;
+            let w1_final = &c.w1_states[s * w1_size..(s + 1) * w1_size];
+            let w2_final = &c.w2_states[s * w2_size..(s + 1) * w2_size];
+            let mut ctx_mem = Vec::with_capacity(w1_size + w2_size);
+            ctx_mem.extend_from_slice(w1_final);
+            ctx_mem.extend_from_slice(w2_final);
+            *context_mem = ctx_mem;
+        }
+        MemoryCache::YAAD(c) => {
+            let dh = c.d_hidden;
+            let w1_size = dh * d;
+            let w2_size = d * dh;
+            let w1_final = &c.w1_states[s * w1_size..(s + 1) * w1_size];
+            let w2_final = &c.w2_states[s * w2_size..(s + 1) * w2_size];
+            let mut ctx_mem = Vec::with_capacity(w1_size + w2_size);
+            ctx_mem.extend_from_slice(w1_final);
+            ctx_mem.extend_from_slice(w2_final);
+            *context_mem = ctx_mem;
+        }
+        MemoryCache::MEMORA(c) => {
+            let dh = c.d_hidden;
+            let w1_size = dh * d;
+            let w2_size = d * dh;
+            let w1_final = &c.w1_states[s * w1_size..(s + 1) * w1_size];
+            let w2_final = &c.w2_states[s * w2_size..(s + 1) * w2_size];
+            let mut ctx_mem = Vec::with_capacity(w1_size + w2_size);
+            ctx_mem.extend_from_slice(w1_final);
+            ctx_mem.extend_from_slice(w2_final);
+            *context_mem = ctx_mem;
+        }
+        MemoryCache::Lattice(c) => {
+            let m = c.m;
+            let s_final = &c.s_states[s * m * d..(s + 1) * m * d];
+            *context_mem = s_final.to_vec();
+        }
+        MemoryCache::Trellis(c) => {
+            let d_k = c.d_k;
+            let sk_size = d_k * d;
+            let sv_size = d * d_k;
+            let sk_final = &c.sk_states[s * sk_size..(s + 1) * sk_size];
+            let sv_final = &c.sv_states[s * sv_size..(s + 1) * sv_size];
+            let mut ctx_mem = Vec::with_capacity(sk_size + sv_size);
+            ctx_mem.extend_from_slice(sk_final);
+            ctx_mem.extend_from_slice(sv_final);
+            *context_mem = ctx_mem;
+        }
+    }
+}
+
+/// Dispatch frozen read-only forward. Returns (y, q_mem).
+fn dispatch_read_only(
+    cfg: &MAGConfig,
+    level_params: &crate::model::MemoryLevelParams,
+    embedded: &[f32],
+    frozen_ref: &[f32],
+    s: usize,
+    d: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    match cfg.memory_rule {
+        MemoryRuleKind::Moneta => moneta_read_only(level_params, embedded, frozen_ref, s, d, cfg.d_hidden),
+        MemoryRuleKind::YAAD => yaad_read_only(level_params, embedded, frozen_ref, s, d, cfg.d_hidden),
+        MemoryRuleKind::MEMORA => memora_read_only(level_params, embedded, frozen_ref, s, d, cfg.d_hidden),
+        MemoryRuleKind::LatticeOSR => lattice_read_only(level_params, embedded, frozen_ref, s, d, cfg.m_slots),
+        MemoryRuleKind::Trellis => trellis_read_only(level_params, embedded, frozen_ref, s, d, cfg.d_compress),
+        _ => delta_rule_read_only(level_params, embedded, frozen_ref, s, d),
+    }
+}
+
+/// Dispatch frozen read-only backward. Returns (level grads, d_embedded).
+fn dispatch_read_only_backward(
+    cfg: &MAGConfig,
+    level_params: &crate::model::MemoryLevelParams,
+    frozen_m: &[f32],
+    q_mem: &[f32],
+    d_y: &[f32],
+    embedded: &[f32],
+    s: usize,
+    d: usize,
+) -> (crate::model::MemoryLevelParams, Vec<f32>) {
+    match cfg.memory_rule {
+        MemoryRuleKind::Moneta => moneta_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_hidden),
+        MemoryRuleKind::YAAD => yaad_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_hidden),
+        MemoryRuleKind::MEMORA => memora_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_hidden),
+        MemoryRuleKind::LatticeOSR => lattice_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.m_slots),
+        MemoryRuleKind::Trellis => trellis_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d, cfg.d_compress),
+        _ => delta_rule_read_only_backward(level_params, frozen_m, q_mem, d_y, embedded, s, d),
+    }
+}
+
+/// CMS MAL forward pass. Returns (loss, cache).
+pub fn cms_mal_forward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    input_ids: &[usize],
+    target_ids: &[usize],
+    pulse: &Pulse,
+    context: &mut ContextState,
+) -> (f32, CMSMALForwardCache) {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+
+    assert_eq!(d, nh * hd);
+    assert!(input_ids.len() >= s);
+    assert!(target_ids.len() >= s);
+    assert_eq!(pulse.active_levels.len(), cfg.k);
+    assert_eq!(context.memory.len(), cfg.k);
+
+    // Stage 1: Embedding lookup
+    let mut embedded = vec![0.0f32; s * d];
+    for t in 0..s {
+        let tok = input_ids[t];
+        assert!(tok < v, "cms_mal_forward: input_ids[{t}]={tok} >= vocab_size {v}");
+        embedded[t * d..(t + 1) * d].copy_from_slice(&params.swa.w_embed[tok * d..(tok + 1) * d]);
+    }
+
+    // Stage 2: Per-level memory dispatch
+    let mut memory_caches: Vec<Option<MemoryCache>> = Vec::with_capacity(cfg.k);
+    let mut q_mem_per_level: Vec<Option<Vec<f32>>> = Vec::with_capacity(cfg.k);
+    let mut frozen_memories: Vec<Option<Vec<f32>>> = Vec::with_capacity(cfg.k);
+    let mut y_per_level: Vec<Vec<f32>> = Vec::with_capacity(cfg.k);
+
+    for level in 0..cfg.k {
+        if pulse.active_levels[level] {
+            let initial_m = Some(std::mem::take(&mut context.memory[level]));
+            let (y_level, mem_cache) = dispatch_memory_step(
+                cfg, &params.levels[level], &embedded, s, d, initial_m,
+            );
+            persist_memory_state(cfg, &mem_cache, s, d, &mut context.memory[level]);
+            y_per_level.push(y_level);
+            memory_caches.push(Some(mem_cache));
+            q_mem_per_level.push(None);
+            frozen_memories.push(None);
+        } else {
+            let frozen_ref = &context.memory[level];
+            let (y_level, q_mem) = dispatch_read_only(
+                cfg, &params.levels[level], &embedded, frozen_ref, s, d,
+            );
+            y_per_level.push(y_level);
+            memory_caches.push(None);
+            q_mem_per_level.push(Some(q_mem));
+            frozen_memories.push(Some(frozen_ref.clone()));
+        }
+    }
+
+    // Combine: m_t_combined = sum of level outputs, with 1/sqrt(k) for k>2
+    let mut m_t_combined = vec![0.0f32; s * d];
+    for y_level in &y_per_level {
+        for i in 0..(s * d) {
+            m_t_combined[i] += y_level[i];
+        }
+    }
+    if cfg.k > 2 {
+        let scale = 1.0 / (cfg.k as f32).sqrt();
+        for i in 0..(s * d) {
+            m_t_combined[i] *= scale;
+        }
+    }
+
+    // Stage 2.5: Residual — attn_input = m_t_combined + embedded
+    let mut attn_input = vec![0.0f32; s * d];
+    for i in 0..(s * d) {
+        attn_input[i] = m_t_combined[i] + embedded[i];
+    }
+
+    // Stage 3: QKV projections on attn_input
+    let mut w_q_t = vec![0.0f32; d * d];
+    let mut w_k_t = vec![0.0f32; d * d];
+    let mut w_v_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_q, &mut w_q_t, d, d);
+    transpose_f32(&params.swa.w_k, &mut w_k_t, d, d);
+    transpose_f32(&params.swa.w_v, &mut w_v_t, d, d);
+
+    let mut q = vec![0.0f32; s * d];
+    let mut k = vec![0.0f32; s * d];
+    let mut vv = vec![0.0f32; s * d];
+    matmul_f32(&attn_input, &w_q_t, &mut q, s, d, d);
+    matmul_f32(&attn_input, &w_k_t, &mut k, s, d, d);
+    matmul_f32(&attn_input, &w_v_t, &mut vv, s, d, d);
+
+    // Stage 4: SWA Attention
+    let mut attn_out = vec![0.0f32; s * d];
+    let mut attn_weights = vec![0.0f32; nh * s * ws];
+    crate::dispatch::swa_forward_dispatch(&q, &k, &vv, &mut attn_out, &mut attn_weights, s, nh, hd, ws);
+
+    // Stage 5: Output projection
+    let mut w_o_t = vec![0.0f32; d * d];
+    transpose_f32(&params.swa.w_o, &mut w_o_t, d, d);
+    let mut projected = vec![0.0f32; s * d];
+    matmul_f32(&attn_out, &w_o_t, &mut projected, s, d, d);
+
+    // Stage 6: Unembed
+    let mut logits = vec![0.0f32; s * v];
+    matmul_f32(&projected, &params.swa.w_unembed, &mut logits, s, d, v);
+
+    // Stage 7: Cross-entropy loss
+    let loss = cross_entropy_loss(&logits, target_ids, s, v);
+
+    let cache = CMSMALForwardCache {
+        embedded, memory_caches, q_mem_per_level, frozen_memories,
+        y_per_level, m_t_combined, attn_input,
+        q, k, v: vv, attn_out, attn_weights,
+        projected, logits,
+        pulse: pulse.clone(),
+    };
+
+    (loss, cache)
+}
+
+/// CMS MAL backward pass. Returns parameter gradients.
+pub fn cms_mal_backward(
+    params: &MAGParams,
+    cfg: &MAGConfig,
+    cache: &CMSMALForwardCache,
+    input_ids: &[usize],
+    target_ids: &[usize],
+    error_buffers: &mut [ErrorBuffer],
+) -> MAGParams {
+    let swa_cfg = &cfg.swa;
+    let s = swa_cfg.seq_len;
+    let d = swa_cfg.d_model;
+    let v = swa_cfg.vocab_size;
+    let nh = swa_cfg.num_heads;
+    let hd = swa_cfg.head_dim;
+    let ws = swa_cfg.window_size;
+
+    let mut grads = MAGParams::zeros_like(cfg);
+
+    // ── Stage 7: Cross-entropy gradient ──────────────────────────────
+    let mut d_logits = vec![0.0f32; s * v];
+    let count = (0..s)
+        .filter(|&t| target_ids.get(t).map_or(false, |&tok| tok < v))
+        .count() as f32;
+    if count > 0.0 {
+        for t in 0..s {
+            let target = match target_ids.get(t) {
+                Some(&tok) if tok < v => tok,
+                _ => continue,
+            };
+            let base = t * v;
+            let row = &cache.logits[base..base + v];
+            let max_val = row.iter().copied().fold(f32::NEG_INFINITY, f32::max);
+            let mut sum_exp = 0.0f32;
+            for j in 0..v {
+                let e = (row[j] - max_val).exp();
+                d_logits[base + j] = e;
+                sum_exp += e;
+            }
+            for j in 0..v {
+                d_logits[base + j] /= sum_exp;
+            }
+            d_logits[base + target] -= 1.0;
+            for j in 0..v {
+                d_logits[base + j] /= count;
+            }
+        }
+    }
+
+    // ── Stage 6: Unembed backward ────────────────────────────────────
+    let mut w_unembed_t = vec![0.0f32; v * d];
+    transpose_f32(&params.swa.w_unembed, &mut w_unembed_t, d, v);
+    let mut d_projected = vec![0.0f32; s * d];
+    matmul_f32(&d_logits, &w_unembed_t, &mut d_projected, s, v, d);
+
+    let mut projected_t = vec![0.0f32; d * s];
+    transpose_f32(&cache.projected, &mut projected_t, s, d);
+    matmul_f32(&projected_t, &d_logits, &mut grads.swa.w_unembed, d, s, v);
+
+    // ── Stage 5: Output projection backward ──────────────────────────
+    let mut d_attn_out = vec![0.0f32; s * d];
+    matmul_f32(&d_projected, &params.swa.w_o, &mut d_attn_out, s, d, d);
+
+    let mut d_projected_t = vec![0.0f32; d * s];
+    transpose_f32(&d_projected, &mut d_projected_t, s, d);
+    matmul_f32(&d_projected_t, &cache.attn_out, &mut grads.swa.w_o, d, s, d);
+
+    // ── Stage 4: SWA Attention backward ─────────────────────────────
+    let mut d_q = vec![0.0f32; s * d];
+    let mut d_k = vec![0.0f32; s * d];
+    let mut d_v = vec![0.0f32; s * d];
+
+    crate::dispatch::swa_backward_dispatch(
+        &cache.q, &cache.k, &cache.v,
+        &cache.attn_weights, &d_attn_out,
+        &mut d_q, &mut d_k, &mut d_v,
+        s, nh, hd, ws,
+    );
+
+    // ── Stage 3: QKV projection backward (inputs are attn_input) ──
+    let mut d_attn_input = vec![0.0f32; s * d];
+
+    crate::tensor::matmul_acc_f32(&d_q, &params.swa.w_q, &mut d_attn_input, s, d, d);
+    crate::tensor::matmul_acc_f32(&d_k, &params.swa.w_k, &mut d_attn_input, s, d, d);
+    crate::tensor::matmul_acc_f32(&d_v, &params.swa.w_v, &mut d_attn_input, s, d, d);
+
+    let mut d_q_t = vec![0.0f32; d * s];
+    transpose_f32(&d_q, &mut d_q_t, s, d);
+    matmul_f32(&d_q_t, &cache.attn_input, &mut grads.swa.w_q, d, s, d);
+
+    let mut d_k_t = vec![0.0f32; d * s];
+    transpose_f32(&d_k, &mut d_k_t, s, d);
+    matmul_f32(&d_k_t, &cache.attn_input, &mut grads.swa.w_k, d, s, d);
+
+    let mut d_v_t = vec![0.0f32; d * s];
+    transpose_f32(&d_v, &mut d_v_t, s, d);
+    matmul_f32(&d_v_t, &cache.attn_input, &mut grads.swa.w_v, d, s, d);
+
+    // ── Stage 2.5: Residual backward (attn_input = m_t_combined + embedded) ──
+    let mut d_m_t = d_attn_input.clone();
+
+    // 1/sqrt(k) normalization chain rule for k>2
+    if cfg.k > 2 {
+        let scale = 1.0 / (cfg.k as f32).sqrt();
+        for i in 0..(s * d) {
+            d_m_t[i] *= scale;
+        }
+    }
+
+    // ── Stage 2: Per-level memory backward ──────────────────────────
+    let mut d_embedded_total = vec![0.0f32; s * d];
+
+    // Residual path: d_attn_input flows directly to embedding
+    for i in 0..(s * d) {
+        d_embedded_total[i] = d_attn_input[i];
+    }
+
+    for level in 0..cfg.k {
+        if cache.pulse.active_levels[level] {
+            let mem_cache = cache.memory_caches[level].as_ref().unwrap();
+            let (mem_grads, d_embedded_mem) = dispatch_memory_backward(
+                cfg, &params.levels[level], mem_cache, &d_m_t, &cache.embedded,
+            );
+            grads.levels[level].accumulate(&mem_grads);
+            for i in 0..(s * d) {
+                d_embedded_total[i] += d_embedded_mem[i];
+            }
+        } else {
+            let q_mem = cache.q_mem_per_level[level].as_ref().unwrap();
+            let frozen_m = cache.frozen_memories[level].as_ref().unwrap();
+            let (mem_grads, d_embedded_mem) = dispatch_read_only_backward(
+                cfg, &params.levels[level], frozen_m, q_mem, &d_m_t, &cache.embedded, s, d,
+            );
+            error_buffers[level].accumulate(&mem_grads);
+            for i in 0..(s * d) {
+                d_embedded_total[i] += d_embedded_mem[i];
+            }
+        }
+    }
+
+    // ── Stage 1: Embedding scatter-add ───────────────────────────────
+    for t in 0..s {
+        let tok = input_ids[t];
+        for dd in 0..d {
+            grads.swa.w_embed[tok * d + dd] += d_embedded_total[t * d + dd];
+        }
+    }
+
+    grads
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{MAGConfig, MAGParams};
+
+    fn test_config() -> MAGConfig {
+        MAGConfig::mal_test_config()
+    }
+
+    fn make_test_data(cfg: &MAGConfig) -> (Vec<usize>, Vec<usize>) {
+        let input_ids: Vec<usize> = (0..cfg.swa.seq_len).collect();
+        let target_ids: Vec<usize> = (1..=cfg.swa.seq_len)
+            .map(|t| t % cfg.swa.vocab_size)
+            .collect();
+        (input_ids, target_ids)
+    }
+
+    #[test]
+    fn test_mal_forward_finite_loss() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (loss, _cache) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+        assert!(loss.is_finite(), "MAL loss not finite: {loss}");
+        assert!(loss > 0.0, "MAL loss should be positive: {loss}");
+        assert!(loss < 20.0, "MAL loss too high: {loss}");
+    }
+
+    #[test]
+    fn test_mal_forward_deterministic() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (loss1, _) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+        let (loss2, _) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+        assert_eq!(loss1, loss2, "MAL forward should be deterministic");
+    }
+
+    #[test]
+    fn test_mal_backward_finite() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (_loss, cache) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+        let grads = mal_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+
+        for (name, g) in [
+            ("w_q", &grads.swa.w_q), ("w_k", &grads.swa.w_k),
+            ("w_v", &grads.swa.w_v), ("w_o", &grads.swa.w_o),
+            ("w_unembed", &grads.swa.w_unembed), ("w_embed", &grads.swa.w_embed),
+            ("w_k_mem", &grads.levels[0].w_k_mem),
+        ] {
+            for (i, &val) in g.iter().enumerate() {
+                assert!(val.is_finite(), "mal grad_{name}[{i}] not finite: {val}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_mal_backward_nonzero() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (_loss, cache) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+        let grads = mal_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+
+        // w_o always has gradient (directly connects to loss).
+        // w_q gradient can be tiny at init because Q = w_q @ m_t and m_t ≈ 0
+        // when memory starts empty and theta_t ≈ 0.01.
+        for (name, g) in [
+            ("w_o", &grads.swa.w_o),
+            ("w_k_mem", &grads.levels[0].w_k_mem),
+        ] {
+            let max_abs = g.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+            assert!(max_abs > 1e-10, "mal grad_{name} all zeros (max_abs={max_abs})");
+        }
+    }
+
+    #[test]
+    fn test_mal_m_t_is_attention_input() {
+        let cfg = test_config();
+        let params = MAGParams::init(&cfg, 42);
+        let (input_ids, target_ids) = make_test_data(&cfg);
+        let (_loss, cache) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+
+        // Verify m_t ≠ embedded (memory actually transforms the input)
+        let diff: f32 = cache.m_t.iter().zip(cache.embedded.iter())
+            .map(|(a, b)| (a - b).abs())
+            .sum();
+        assert!(diff > 1e-6, "m_t should differ from embedded, diff={diff}");
+    }
+}

--- a/core/src/model.rs
+++ b/core/src/model.rs
@@ -5,6 +5,19 @@
 
 use crate::tensor::SimpleRng;
 
+/// Which composition pattern to use (Titans Section 4).
+///
+/// Three ways memory connects to attention — orthogonal to memory rule choice.
+/// - MAG: Memory gates attention output via sigmoid (parallel branches)
+/// - MAL: Memory preprocesses input, attention processes memory output (simplest)
+/// - MAC: Memory provides context, attention processes assembled input (most expressive)
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CompositionKind {
+    MAG,
+    MAL,
+    MAC,
+}
+
 /// Which memory update rule to use for the inner loop.
 ///
 /// MIRAS Algorithm knob: selects the optimizer for memory updates.
@@ -281,6 +294,8 @@ impl MemoryLevelParams {
 pub struct MAGConfig {
     pub swa: SWAConfig,
     pub memory_enabled: bool,
+    /// Which composition pattern to use (MAG, MAL, MAC).
+    pub composition: CompositionKind,
     /// Which memory update rule to use.
     pub memory_rule: MemoryRuleKind,
     /// Number of CMS frequency levels (1 for Zero-B, 2 for Phase 2).
@@ -363,6 +378,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::DeltaRule,
             k: 1,
             chunk_sizes: vec![1],
@@ -382,6 +398,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::DeltaRule,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -401,6 +418,7 @@ impl MAGConfig {
                 vocab_size: 64,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::DeltaRule,
             k: 1,
             chunk_sizes: vec![1],
@@ -421,6 +439,7 @@ impl MAGConfig {
                 vocab_size: 64,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::DeltaRule,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -441,6 +460,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::DeltaRule,
             k: 4,
             chunk_sizes: vec![1, 8, 64, 512],
@@ -461,6 +481,7 @@ impl MAGConfig {
                 vocab_size: 64,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::DeltaRule,
             k: 4,
             chunk_sizes: vec![1, 8, 64, 512],
@@ -480,6 +501,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::TitansLMM,
             k: 1,
             chunk_sizes: vec![1],
@@ -499,6 +521,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::HebbianRule,
             k: 1,
             chunk_sizes: vec![1],
@@ -518,6 +541,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::HebbianRule,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -537,6 +561,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::TitansLMM,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -556,6 +581,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::Moneta,
             k: 1,
             chunk_sizes: vec![1],
@@ -584,6 +610,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::Moneta,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -612,6 +639,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::YAAD,
             k: 1,
             chunk_sizes: vec![1],
@@ -640,6 +668,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::YAAD,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -668,6 +697,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::MEMORA,
             k: 1,
             chunk_sizes: vec![1],
@@ -696,6 +726,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::MEMORA,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -724,6 +755,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::LatticeOSR,
             k: 1,
             chunk_sizes: vec![1],
@@ -744,6 +776,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::LatticeOSR,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -764,6 +797,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::Trellis,
             k: 1,
             chunk_sizes: vec![1],
@@ -787,6 +821,7 @@ impl MAGConfig {
                 vocab_size: 16,
             },
             memory_enabled: true,
+            composition: CompositionKind::MAG,
             memory_rule: MemoryRuleKind::Trellis,
             k: 2,
             chunk_sizes: vec![1, 8],
@@ -795,6 +830,87 @@ impl MAGConfig {
             d_compress: 8,
             lambda_k: 0.01,
             lambda_v: 0.01,
+        }
+    }
+
+    /// MAL test configuration: d=8, k=1, DeltaRule.
+    pub fn mal_test_config() -> Self {
+        MAGConfig {
+            swa: SWAConfig {
+                d_model: 8,
+                num_heads: 2,
+                head_dim: 4,
+                seq_len: 4,
+                window_size: 4,
+                vocab_size: 16,
+            },
+            memory_enabled: true,
+            composition: CompositionKind::MAL,
+            memory_rule: MemoryRuleKind::DeltaRule,
+            k: 1,
+            chunk_sizes: vec![1],
+            d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        }
+    }
+
+    /// MAL test configuration for CMS k=2 testing.
+    pub fn mal_test_config_k2() -> Self {
+        MAGConfig {
+            swa: SWAConfig {
+                d_model: 8,
+                num_heads: 2,
+                head_dim: 4,
+                seq_len: 8,
+                window_size: 8,
+                vocab_size: 16,
+            },
+            memory_enabled: true,
+            composition: CompositionKind::MAL,
+            memory_rule: MemoryRuleKind::DeltaRule,
+            k: 2,
+            chunk_sizes: vec![1, 8],
+            d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        }
+    }
+
+    /// MAC test configuration: d=8, k=1, DeltaRule.
+    /// window_size=16 (2×seq_len) for full causal attention on assembled (2s, d).
+    pub fn mac_test_config() -> Self {
+        MAGConfig {
+            swa: SWAConfig {
+                d_model: 8,
+                num_heads: 2,
+                head_dim: 4,
+                seq_len: 4,
+                window_size: 8,   // 2 * seq_len for assembled input
+                vocab_size: 16,
+            },
+            memory_enabled: true,
+            composition: CompositionKind::MAC,
+            memory_rule: MemoryRuleKind::DeltaRule,
+            k: 1,
+            chunk_sizes: vec![1],
+            d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        }
+    }
+
+    /// MAC test configuration for CMS k=2 testing.
+    pub fn mac_test_config_k2() -> Self {
+        MAGConfig {
+            swa: SWAConfig {
+                d_model: 8,
+                num_heads: 2,
+                head_dim: 4,
+                seq_len: 8,
+                window_size: 16,  // 2 * seq_len for assembled input
+                vocab_size: 16,
+            },
+            memory_enabled: true,
+            composition: CompositionKind::MAC,
+            memory_rule: MemoryRuleKind::DeltaRule,
+            k: 2,
+            chunk_sizes: vec![1, 8],
+            d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
         }
     }
 }

--- a/core/tests/test_cms.rs
+++ b/core/tests/test_cms.rs
@@ -1,6 +1,6 @@
 //! CMS integration tests: multi-step training, error buffer health, falsification.
 
-use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
 use nl_hecate_core::mag::{cms_forward, cms_backward};
 use nl_hecate_core::conductor::{Conductor, Pulse, ContextState, ErrorBuffer};
 
@@ -202,6 +202,7 @@ fn test_k2_beats_k1() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 1, chunk_sizes: vec![1],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
     // k=2 config
     let cfg_k2 = MAGConfig {
@@ -209,6 +210,7 @@ fn test_k2_beats_k1() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 2, chunk_sizes: vec![1, 8],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();
@@ -381,12 +383,14 @@ fn test_k4_vs_k2_multiscale() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 2, chunk_sizes: vec![1, 8],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
     let cfg_k4 = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 4, chunk_sizes: vec![1, 8, 64, 512],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let slow_period = 8;
@@ -470,6 +474,7 @@ fn test_k4_diagnostics() {
         k: 4,
         chunk_sizes: vec![1, 8, 64, 512],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let (input_ids, target_ids) = make_multiscale_data(
@@ -731,12 +736,14 @@ fn test_cms_stability_boundary() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 1, chunk_sizes: vec![1],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
     let cfg_k2 = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 2, chunk_sizes: vec![1, 8],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let slow_period = 8;
@@ -917,6 +924,7 @@ fn test_k4_normalization_magnitude() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 4, chunk_sizes: vec![1, 8, 64, 512],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
     let params_k4 = MAGParams::init(&cfg_k4, 42);
     let mut context = ContextState::new(cfg_k4.k, cfg_k4.swa.d_model);
@@ -976,6 +984,7 @@ fn test_k4_uniform_init_stable() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 4, chunk_sizes: vec![1, 8, 64, 512],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let (input_ids, target_ids) = make_multiscale_data(
@@ -1021,6 +1030,7 @@ fn test_k4_normalized_stable() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 4, chunk_sizes: vec![1, 8, 64, 512],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let (input_ids, target_ids) = make_multiscale_data(

--- a/core/tests/test_hebbian.rs
+++ b/core/tests/test_hebbian.rs
@@ -1,6 +1,6 @@
 //! Hebbian Rule integration tests: multi-step training, comparison vs Delta Rule.
 
-use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
 use nl_hecate_core::mag::{cms_forward, cms_backward, mag_forward, mag_backward, MemoryCache};
 use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
 
@@ -190,12 +190,14 @@ fn test_hebbian_vs_delta() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 1, chunk_sizes: vec![1],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
     let cfg_hebbian = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
         memory_rule: MemoryRuleKind::HebbianRule,
         k: 1, chunk_sizes: vec![1],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();

--- a/core/tests/test_lattice.rs
+++ b/core/tests/test_lattice.rs
@@ -1,6 +1,6 @@
 //! Lattice OSR integration tests: multi-step training, sphere preservation, CMS k=2, comparison vs Delta Rule.
 
-use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
 use nl_hecate_core::mag::{cms_forward, cms_backward, mag_forward, mag_backward, MemoryCache};
 use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
 use nl_hecate_core::tensor::vec_norm_f32;
@@ -208,12 +208,14 @@ fn test_lattice_vs_delta() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 1, chunk_sizes: vec![1],
         d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
     };
     let cfg_lattice = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
         memory_rule: MemoryRuleKind::LatticeOSR,
         k: 1, chunk_sizes: vec![1],
         d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 4, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
     };
 
     let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();

--- a/core/tests/test_mac.rs
+++ b/core/tests/test_mac.rs
@@ -1,0 +1,257 @@
+//! MAC (Memory As Context) integration tests: multi-step training,
+//! reflective gate verification, CMS k=2, comparison vs MAG.
+
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
+use nl_hecate_core::mac::{mac_forward, mac_backward, cms_mac_forward, cms_mac_backward};
+use nl_hecate_core::mag::{mag_forward, mag_backward};
+use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
+
+fn make_data(cfg: &MAGConfig) -> (Vec<usize>, Vec<usize>) {
+    let input_ids: Vec<usize> = (0..cfg.swa.seq_len).map(|t| t % cfg.swa.vocab_size).collect();
+    let target_ids: Vec<usize> = (1..=cfg.swa.seq_len).map(|t| t % cfg.swa.vocab_size).collect();
+    (input_ids, target_ids)
+}
+
+fn make_multiscale_data(
+    seq_len: usize,
+    vocab_size: usize,
+    slow_period: usize,
+    num_regimes: usize,
+) -> (Vec<usize>, Vec<usize>) {
+    let tokens_per_regime = vocab_size / num_regimes;
+    let mut input_ids = Vec::with_capacity(seq_len);
+    let mut target_ids = Vec::with_capacity(seq_len);
+
+    for t in 0..seq_len {
+        let slow_regime = (t / slow_period) % num_regimes;
+        let fast_component = (t * 3 + 1) % tokens_per_regime;
+        let input = (t * 7 + slow_regime * 3) % vocab_size;
+        let target = (fast_component + slow_regime * tokens_per_regime) % vocab_size;
+        input_ids.push(input);
+        target_ids.push(target);
+    }
+
+    (input_ids, target_ids)
+}
+
+/// CMS training loop for MAC. Returns (initial_loss, final_loss).
+fn cms_mac_train(
+    params: &mut MAGParams,
+    cfg: &MAGConfig,
+    input_ids: &[usize],
+    target_ids: &[usize],
+    steps: usize,
+    lr: f32,
+) -> (f32, f32) {
+    let mut conductor = Conductor::new(cfg.k, cfg.chunk_sizes.clone());
+    let d = cfg.swa.d_model;
+    let mut context = ContextState::new(cfg.k, d);
+    let mut error_buffers: Vec<ErrorBuffer> = (0..cfg.k)
+        .map(|_| ErrorBuffer::new(d))
+        .collect();
+
+    let mut initial_loss = None;
+    let mut final_loss = 0.0f32;
+
+    for _ in 0..steps {
+        let pulse = conductor.pulse();
+        let (loss, cache) = cms_mac_forward(params, cfg, input_ids, target_ids, &pulse, &mut context);
+        if initial_loss.is_none() {
+            initial_loss = Some(loss);
+        }
+        final_loss = loss;
+
+        let grads = cms_mac_backward(params, cfg, &cache, input_ids, target_ids, &mut error_buffers);
+        params.sgd_step(&grads, lr);
+
+        for level in 0..cfg.k {
+            if pulse.active_levels[level] && error_buffers[level].steps_accumulated > 0 {
+                error_buffers[level].apply_and_reset(&mut params.levels[level], lr);
+            }
+        }
+
+        conductor.advance();
+    }
+
+    (initial_loss.unwrap(), final_loss)
+}
+
+// ── MAC k=1 tests ──────────────────────────────────────────
+
+/// 100-step smoke test: no NaN, no divergence, loss finite.
+#[test]
+fn test_mac_k1_smoke() {
+    let cfg = MAGConfig::mac_test_config();
+    let mut params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_data(&cfg);
+
+    let mut prev_loss = None;
+    for step in 0..100 {
+        let (loss, cache) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+        assert!(loss.is_finite(), "Loss NaN at step {step}");
+        if prev_loss.is_none() {
+            prev_loss = Some(loss);
+        }
+
+        let grads = mac_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+        params.sgd_step(&grads, 0.01);
+    }
+
+    let final_loss = mac_forward(&params, &cfg, &input_ids, &target_ids).0;
+    let initial = prev_loss.unwrap();
+    eprintln!("MAC k=1 smoke: initial={initial:.4}, final={final_loss:.4}");
+    assert!(final_loss.is_finite(), "Final loss not finite");
+    assert!(final_loss < 100.0, "Loss diverged: {final_loss}");
+}
+
+/// 1K-step convergence: loss decreases.
+#[test]
+fn test_mac_k1_convergence() {
+    let cfg = MAGConfig::mac_test_config();
+    let mut params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_data(&cfg);
+
+    let mut initial_loss = None;
+    for _ in 0..1_000 {
+        let (loss, cache) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+        if initial_loss.is_none() {
+            initial_loss = Some(loss);
+        }
+        let grads = mac_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+        params.sgd_step(&grads, 0.01);
+    }
+
+    let final_loss = mac_forward(&params, &cfg, &input_ids, &target_ids).0;
+    let initial = initial_loss.unwrap();
+    eprintln!("MAC k=1 convergence: initial={initial:.4}, final={final_loss:.4}");
+    assert!(final_loss < initial,
+        "Loss should decrease: initial={initial:.4}, final={final_loss:.4}");
+}
+
+/// Verify the reflective gate is correctly computed (sigmoid output in (0,1)).
+/// At init with conservative theta_t ≈ 0.01, reflective_y ≈ 0 so gate ≈ 0.5.
+/// This is expected — the convergence test validates that MAC learns through this path.
+#[test]
+fn test_mac_reflective_gate_active() {
+    let cfg = MAGConfig::mac_test_config();
+    let params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_data(&cfg);
+
+    let (_, cache) = mac_forward(&params, &cfg, &input_ids, &target_ids);
+
+    // Gate should be in (0, 1) range (sigmoid output)
+    for (i, &g) in cache.reflective_gate.iter().enumerate() {
+        assert!(g >= 0.0 && g <= 1.0,
+            "Gate value at {i} should be in [0,1]: {g}");
+    }
+
+    let gate_mean: f32 = cache.reflective_gate.iter().sum::<f32>()
+        / cache.reflective_gate.len() as f32;
+    eprintln!("MAC reflective gate mean: {gate_mean:.4} (expect ~0.5 at init)");
+
+    // Gate should be finite and non-NaN
+    assert!(gate_mean.is_finite(), "Gate mean should be finite");
+
+    // With DeltaRule at d=8, reflective_y has non-zero norm after step updates M
+    let ry_norm: f32 = cache.reflective_y.iter()
+        .map(|x| x * x).sum::<f32>().sqrt();
+    eprintln!("MAC reflective_y norm: {ry_norm:.4e}");
+    // reflective_y can be very small at init (theta ≈ 0.01, d=8) — just verify finite
+    assert!(ry_norm.is_finite(), "reflective_y should be finite");
+}
+
+/// CMS k=2 with MAC on multi-scale data.
+#[test]
+fn test_mac_k2_multiscale() {
+    let cfg = MAGConfig::mac_test_config_k2();
+    let mut params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_multiscale_data(
+        cfg.swa.seq_len, cfg.swa.vocab_size, 4, 4,
+    );
+
+    let (initial, final_loss) = cms_mac_train(&mut params, &cfg, &input_ids, &target_ids, 5_000, 0.01);
+    eprintln!("MAC k=2 multiscale: initial={initial:.4}, final={final_loss:.4}");
+
+    assert!(initial.is_finite(), "Initial loss not finite");
+    assert!(final_loss.is_finite(), "Final loss not finite");
+    assert!(final_loss < initial,
+        "Loss should decrease: initial={initial:.4}, final={final_loss:.4}");
+}
+
+/// Compare MAC vs MAG on same data. Both should converge, within tolerance.
+#[test]
+fn test_mac_vs_mag() {
+    use nl_hecate_core::model::SWAConfig;
+
+    let swa_mag = SWAConfig {
+        d_model: 8, num_heads: 2, head_dim: 4,
+        seq_len: 8, window_size: 8, vocab_size: 16,
+    };
+    // MAC needs window_size >= 2*seq_len for full causal on assembled input
+    let swa_mac = SWAConfig {
+        d_model: 8, num_heads: 2, head_dim: 4,
+        seq_len: 8, window_size: 16, vocab_size: 16,
+    };
+
+    let cfg_mag = MAGConfig {
+        swa: swa_mag.clone(), memory_enabled: true,
+        memory_rule: MemoryRuleKind::DeltaRule,
+        k: 1, chunk_sizes: vec![1],
+        d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
+    };
+    let cfg_mac = MAGConfig {
+        swa: swa_mac, memory_enabled: true,
+        memory_rule: MemoryRuleKind::DeltaRule,
+        k: 1, chunk_sizes: vec![1],
+        d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAC,
+    };
+
+    let seq_len = 8;
+    let vocab_size = 16;
+    let input_ids: Vec<usize> = (0..seq_len).map(|t| t % vocab_size).collect();
+    let target_ids: Vec<usize> = (1..=seq_len).map(|t| t % vocab_size).collect();
+    let lr = 0.01;
+    let steps = 5_000;
+
+    // Train MAG
+    let mut params_mag = MAGParams::init(&cfg_mag, 42);
+    let mut mag_initial = None;
+    for _ in 0..steps {
+        let (loss, cache) = mag_forward(&params_mag, &cfg_mag, &input_ids, &target_ids);
+        if mag_initial.is_none() { mag_initial = Some(loss); }
+        let grads = mag_backward(&params_mag, &cfg_mag, &cache, &input_ids, &target_ids);
+        params_mag.sgd_step(&grads, lr);
+    }
+    let mag_final = mag_forward(&params_mag, &cfg_mag, &input_ids, &target_ids).0;
+
+    // Train MAC
+    let mut params_mac = MAGParams::init(&cfg_mac, 42);
+    let mut mac_initial = None;
+    for _ in 0..steps {
+        let (loss, cache) = mac_forward(&params_mac, &cfg_mac, &input_ids, &target_ids);
+        if mac_initial.is_none() { mac_initial = Some(loss); }
+        let grads = mac_backward(&params_mac, &cfg_mac, &cache, &input_ids, &target_ids);
+        params_mac.sgd_step(&grads, lr);
+    }
+    let mac_final = mac_forward(&params_mac, &cfg_mac, &input_ids, &target_ids).0;
+
+    eprintln!("MAG: initial={:.4}, final={mag_final:.4}", mag_initial.unwrap());
+    eprintln!("MAC: initial={:.4}, final={mac_final:.4}", mac_initial.unwrap());
+
+    // Both should converge
+    assert!(mag_final < mag_initial.unwrap(), "MAG should converge");
+    assert!(mac_final < mac_initial.unwrap(), "MAC should converge");
+
+    // MAC should be in same ballpark as MAG (different composition, not necessarily better at d=8)
+    assert!(mac_final < mag_final * 5.0,
+        "MAC should not catastrophically regress: mac={mac_final:.6}, mag={mag_final:.6}");
+
+    let ratio = if mac_final > mag_final {
+        mac_final / mag_final
+    } else {
+        mag_final / mac_final
+    };
+    eprintln!("Performance ratio: {ratio:.2}x (closer to 1.0 = more similar)");
+}

--- a/core/tests/test_mal.rs
+++ b/core/tests/test_mal.rs
@@ -1,0 +1,241 @@
+//! MAL (Memory As Layer) integration tests: multi-step training,
+//! memory-is-attention-input verification, CMS k=2, comparison vs MAG.
+
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
+use nl_hecate_core::mal::{mal_forward, mal_backward, cms_mal_forward, cms_mal_backward};
+use nl_hecate_core::mag::{mag_forward, mag_backward};
+use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
+
+fn make_data(cfg: &MAGConfig) -> (Vec<usize>, Vec<usize>) {
+    let input_ids: Vec<usize> = (0..cfg.swa.seq_len).map(|t| t % cfg.swa.vocab_size).collect();
+    let target_ids: Vec<usize> = (1..=cfg.swa.seq_len).map(|t| t % cfg.swa.vocab_size).collect();
+    (input_ids, target_ids)
+}
+
+fn make_multiscale_data(
+    seq_len: usize,
+    vocab_size: usize,
+    slow_period: usize,
+    num_regimes: usize,
+) -> (Vec<usize>, Vec<usize>) {
+    let tokens_per_regime = vocab_size / num_regimes;
+    let mut input_ids = Vec::with_capacity(seq_len);
+    let mut target_ids = Vec::with_capacity(seq_len);
+
+    for t in 0..seq_len {
+        let slow_regime = (t / slow_period) % num_regimes;
+        let fast_component = (t * 3 + 1) % tokens_per_regime;
+        let input = (t * 7 + slow_regime * 3) % vocab_size;
+        let target = (fast_component + slow_regime * tokens_per_regime) % vocab_size;
+        input_ids.push(input);
+        target_ids.push(target);
+    }
+
+    (input_ids, target_ids)
+}
+
+/// CMS training loop for MAL. Returns (initial_loss, final_loss).
+fn cms_mal_train(
+    params: &mut MAGParams,
+    cfg: &MAGConfig,
+    input_ids: &[usize],
+    target_ids: &[usize],
+    steps: usize,
+    lr: f32,
+) -> (f32, f32) {
+    let mut conductor = Conductor::new(cfg.k, cfg.chunk_sizes.clone());
+    let d = cfg.swa.d_model;
+    let mut context = ContextState::new(cfg.k, d);
+    let mut error_buffers: Vec<ErrorBuffer> = (0..cfg.k)
+        .map(|_| ErrorBuffer::new(d))
+        .collect();
+
+    let mut initial_loss = None;
+    let mut final_loss = 0.0f32;
+
+    for _ in 0..steps {
+        let pulse = conductor.pulse();
+        let (loss, cache) = cms_mal_forward(params, cfg, input_ids, target_ids, &pulse, &mut context);
+        if initial_loss.is_none() {
+            initial_loss = Some(loss);
+        }
+        final_loss = loss;
+
+        let grads = cms_mal_backward(params, cfg, &cache, input_ids, target_ids, &mut error_buffers);
+        params.sgd_step(&grads, lr);
+
+        for level in 0..cfg.k {
+            if pulse.active_levels[level] && error_buffers[level].steps_accumulated > 0 {
+                error_buffers[level].apply_and_reset(&mut params.levels[level], lr);
+            }
+        }
+
+        conductor.advance();
+    }
+
+    (initial_loss.unwrap(), final_loss)
+}
+
+// ── MAL k=1 tests ──────────────────────────────────────────
+
+/// 100-step smoke test: no NaN, no divergence, loss finite.
+#[test]
+fn test_mal_k1_smoke() {
+    let cfg = MAGConfig::mal_test_config();
+    let mut params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_data(&cfg);
+
+    let mut prev_loss = None;
+    for step in 0..100 {
+        let (loss, cache) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+        assert!(loss.is_finite(), "Loss NaN at step {step}");
+        if prev_loss.is_none() {
+            prev_loss = Some(loss);
+        }
+
+        let grads = mal_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+        params.sgd_step(&grads, 0.01);
+    }
+
+    let final_loss = mal_forward(&params, &cfg, &input_ids, &target_ids).0;
+    let initial = prev_loss.unwrap();
+    eprintln!("MAL k=1 smoke: initial={initial:.4}, final={final_loss:.4}");
+    assert!(final_loss.is_finite(), "Final loss not finite");
+    assert!(final_loss < 100.0, "Loss diverged: {final_loss}");
+}
+
+/// 1K-step convergence: loss decreases.
+#[test]
+fn test_mal_k1_convergence() {
+    let cfg = MAGConfig::mal_test_config();
+    let mut params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_data(&cfg);
+
+    let mut initial_loss = None;
+    for _ in 0..1_000 {
+        let (loss, cache) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+        if initial_loss.is_none() {
+            initial_loss = Some(loss);
+        }
+        let grads = mal_backward(&params, &cfg, &cache, &input_ids, &target_ids);
+        params.sgd_step(&grads, 0.01);
+    }
+
+    let final_loss = mal_forward(&params, &cfg, &input_ids, &target_ids).0;
+    let initial = initial_loss.unwrap();
+    eprintln!("MAL k=1 convergence: initial={initial:.4}, final={final_loss:.4}");
+    assert!(final_loss < initial,
+        "Loss should decrease: initial={initial:.4}, final={final_loss:.4}");
+}
+
+/// Verify that attention Q,K,V are computed from memory output m_t, not raw embedded.
+/// In MAL, memory preprocesses the input — the cache should show m_t differs from embedded.
+#[test]
+fn test_mal_memory_is_attention_input() {
+    let cfg = MAGConfig::mal_test_config();
+    let params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_data(&cfg);
+
+    let (_, cache) = mal_forward(&params, &cfg, &input_ids, &target_ids);
+
+    // m_t (memory output) should differ from embedded (raw input)
+    let diff: f32 = cache.embedded.iter().zip(cache.m_t.iter())
+        .map(|(a, b)| (a - b).powi(2)).sum::<f32>().sqrt();
+
+    eprintln!("MAL memory-is-input: ||embedded - m_t|| = {diff:.4e}");
+    assert!(diff > 1e-6,
+        "m_t should differ from embedded (memory should transform input): diff={diff:.4e}");
+
+    // Also verify m_t is non-zero (memory is producing output)
+    let m_t_norm: f32 = cache.m_t.iter().map(|x| x * x).sum::<f32>().sqrt();
+    assert!(m_t_norm > 1e-6, "m_t should be non-zero: norm={m_t_norm:.4e}");
+}
+
+/// CMS k=2 with MAL on multi-scale data.
+#[test]
+fn test_mal_k2_multiscale() {
+    let cfg = MAGConfig::mal_test_config_k2();
+    let mut params = MAGParams::init(&cfg, 42);
+    let (input_ids, target_ids) = make_multiscale_data(
+        cfg.swa.seq_len, cfg.swa.vocab_size, 4, 4,
+    );
+
+    let (initial, final_loss) = cms_mal_train(&mut params, &cfg, &input_ids, &target_ids, 5_000, 0.01);
+    eprintln!("MAL k=2 multiscale: initial={initial:.4}, final={final_loss:.4}");
+
+    assert!(initial.is_finite(), "Initial loss not finite");
+    assert!(final_loss.is_finite(), "Final loss not finite");
+    assert!(final_loss < initial,
+        "Loss should decrease: initial={initial:.4}, final={final_loss:.4}");
+}
+
+/// Compare MAL vs MAG on same data. Both should converge, within tolerance.
+#[test]
+fn test_mal_vs_mag() {
+    use nl_hecate_core::model::SWAConfig;
+
+    let swa = SWAConfig {
+        d_model: 8, num_heads: 2, head_dim: 4,
+        seq_len: 8, window_size: 8, vocab_size: 16,
+    };
+
+    let cfg_mag = MAGConfig {
+        swa: swa.clone(), memory_enabled: true,
+        memory_rule: MemoryRuleKind::DeltaRule,
+        k: 1, chunk_sizes: vec![1],
+        d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
+    };
+    let cfg_mal = MAGConfig {
+        swa: swa.clone(), memory_enabled: true,
+        memory_rule: MemoryRuleKind::DeltaRule,
+        k: 1, chunk_sizes: vec![1],
+        d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAL,
+    };
+
+    let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();
+    let target_ids: Vec<usize> = (1..=swa.seq_len).map(|t| t % swa.vocab_size).collect();
+    let lr = 0.01;
+    let steps = 5_000;
+
+    // Train MAG
+    let mut params_mag = MAGParams::init(&cfg_mag, 42);
+    let mut mag_initial = None;
+    for _ in 0..steps {
+        let (loss, cache) = mag_forward(&params_mag, &cfg_mag, &input_ids, &target_ids);
+        if mag_initial.is_none() { mag_initial = Some(loss); }
+        let grads = mag_backward(&params_mag, &cfg_mag, &cache, &input_ids, &target_ids);
+        params_mag.sgd_step(&grads, lr);
+    }
+    let mag_final = mag_forward(&params_mag, &cfg_mag, &input_ids, &target_ids).0;
+
+    // Train MAL
+    let mut params_mal = MAGParams::init(&cfg_mal, 42);
+    let mut mal_initial = None;
+    for _ in 0..steps {
+        let (loss, cache) = mal_forward(&params_mal, &cfg_mal, &input_ids, &target_ids);
+        if mal_initial.is_none() { mal_initial = Some(loss); }
+        let grads = mal_backward(&params_mal, &cfg_mal, &cache, &input_ids, &target_ids);
+        params_mal.sgd_step(&grads, lr);
+    }
+    let mal_final = mal_forward(&params_mal, &cfg_mal, &input_ids, &target_ids).0;
+
+    eprintln!("MAG: initial={:.4}, final={mag_final:.4}", mag_initial.unwrap());
+    eprintln!("MAL: initial={:.4}, final={mal_final:.4}", mal_initial.unwrap());
+
+    // Both should converge
+    assert!(mag_final < mag_initial.unwrap(), "MAG should converge");
+    assert!(mal_final < mal_initial.unwrap(), "MAL should converge");
+
+    // MAL should be in same ballpark as MAG (different composition, not necessarily better at d=8)
+    assert!(mal_final < mag_final * 5.0,
+        "MAL should not catastrophically regress: mal={mal_final:.6}, mag={mag_final:.6}");
+
+    let ratio = if mal_final > mag_final {
+        mal_final / mag_final
+    } else {
+        mag_final / mal_final
+    };
+    eprintln!("Performance ratio: {ratio:.2}x (closer to 1.0 = more similar)");
+}

--- a/core/tests/test_moneta.rs
+++ b/core/tests/test_moneta.rs
@@ -1,6 +1,6 @@
 //! MONETA integration tests: 2-layer MLP memory with l_p bias and L2 retention.
 
-use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
 use nl_hecate_core::mag::{cms_forward, cms_backward, mag_forward, mag_backward, MemoryCache};
 use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
 
@@ -198,12 +198,14 @@ fn test_moneta_vs_delta() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 1, chunk_sizes: vec![1],
         d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
     };
     let cfg_moneta = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
         memory_rule: MemoryRuleKind::Moneta,
         k: 1, chunk_sizes: vec![1],
         d_hidden: 4, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.01, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
     };
 
     let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();

--- a/core/tests/test_titans.rs
+++ b/core/tests/test_titans.rs
@@ -1,6 +1,6 @@
 //! Titans LMM integration tests: multi-step training, momentum validation, comparison vs Delta Rule.
 
-use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
 use nl_hecate_core::mag::{cms_forward, cms_backward, mag_forward, mag_backward, MemoryCache};
 use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
 
@@ -192,12 +192,14 @@ fn test_titans_vs_delta() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 1, chunk_sizes: vec![1],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
     let cfg_titans = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
         memory_rule: MemoryRuleKind::TitansLMM,
         k: 1, chunk_sizes: vec![1],
             d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+            composition: CompositionKind::MAG,
     };
 
     let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();

--- a/core/tests/test_trellis.rs
+++ b/core/tests/test_trellis.rs
@@ -1,7 +1,7 @@
 //! Trellis two-pass KV compression integration tests: multi-step training,
 //! two-pass state evolution, CMS k=2, comparison vs Delta Rule.
 
-use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
 use nl_hecate_core::mag::{cms_forward, cms_backward, mag_forward, mag_backward, MemoryCache};
 use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
 
@@ -210,6 +210,7 @@ fn test_trellis_vs_delta() {
         k: 1, chunk_sizes: vec![1],
         d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0,
         d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
     };
     let cfg_trellis = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
@@ -217,6 +218,7 @@ fn test_trellis_vs_delta() {
         k: 1, chunk_sizes: vec![1],
         d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0,
         d_compress: 8, lambda_k: 0.01, lambda_v: 0.01,
+        composition: CompositionKind::MAG,
     };
 
     let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();

--- a/core/tests/test_yaad.rs
+++ b/core/tests/test_yaad.rs
@@ -1,6 +1,6 @@
 //! YAAD integration tests: 2-layer MLP memory with Huber loss and decoupled retention.
 
-use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind};
+use nl_hecate_core::model::{MAGConfig, MAGParams, MemoryRuleKind, CompositionKind};
 use nl_hecate_core::mag::{cms_forward, cms_backward, mag_forward, mag_backward, MemoryCache};
 use nl_hecate_core::conductor::{Conductor, ContextState, ErrorBuffer};
 
@@ -210,12 +210,14 @@ fn test_yaad_vs_delta() {
         memory_rule: MemoryRuleKind::DeltaRule,
         k: 1, chunk_sizes: vec![1],
         d_hidden: 0, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.0, lambda_2: 0.0, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
     };
     let cfg_yaad = MAGConfig {
         swa: swa.clone(), memory_enabled: true,
         memory_rule: MemoryRuleKind::YAAD,
         k: 1, chunk_sizes: vec![1],
         d_hidden: 4, lp_p: 2.0, lq_q: 2.0, lambda_local: 0.01, lambda_2: 0.01, delta: 1.0, m_slots: 0, d_compress: 0, lambda_k: 0.0, lambda_v: 0.0,
+        composition: CompositionKind::MAG,
     };
 
     let input_ids: Vec<usize> = (0..swa.seq_len).map(|t| t % swa.vocab_size).collect();


### PR DESCRIPTION
## Summary

- Implements **MAC** (Memory As Context) and **MAL** (Memory As Layer) composition patterns from Titans Section 4, completing the **3×8 design space** (3 compositions × 8 MIRAS memory rules)
- Adds `CompositionKind` enum (`MAG`/`MAL`/`MAC`) with dispatch — all 8 memory rules work with any composition
- 42 new FD gradient tests + 10 integration tests validate both patterns at k=1 and CMS k=2
- **501 Rust + 27 Python = 528 total tests pass, 0 failures** (up from 466)

### Key design decisions

**MAL residual**: Pure MAL creates a bootstrapping deadlock at init (m_t ≈ 0 → zero SWA gradients). Added `attn_input = m_t + embedded` residual so the model can train from scratch while memory learns to preprocess.

**MAC assembled attention**: MAC concatenates `h_t` (read-only memory) with `embedded` into a 2s×d assembled tensor, requiring `window_size >= 2*seq_len` for full causal attention. Reflective gate = `y_t * sigmoid(memory.step(y_t))`.

## Test plan

- [x] All 42 MAL/MAC FD gradient tests pass (7 k=1 + 14 CMS k=2, each pattern)
- [x] MAL: smoke (100 steps), convergence (1K steps), memory-is-attention-input, k=2 multiscale (5K steps), vs MAG comparison
- [x] MAC: smoke (100 steps), convergence (1K steps), reflective gate verification, k=2 multiscale (5K steps), vs MAG comparison
- [x] All 439 pre-existing Rust tests pass (no regression)
- [x] All 27 Python tests pass
- [x] `RUSTUP_TOOLCHAIN=enzyme RUSTFLAGS="-Zautodiff=Enable" cargo +enzyme test --release --lib --tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new memory composition architectures: Memory As Layer (MAL) and Memory As Context (MAC), enabling alternative approaches beyond the standard composition.
  * Configuration now supports selecting between MAG, MAL, and MAC composition patterns.
  * Python API updated to expose composition selection with default "mag" option.

* **Tests**
  * Comprehensive test suites added for MAC and MAL architectures, including convergence validation and cross-architecture comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->