### PR TITLE
Add full 100K stability sweep: 72 tests across all rule/composition/k combos

### DIFF
--- a/core/tests/test_stability_sweep.rs
+++ b/core/tests/test_stability_sweep.rs
@@ -166,7 +166,7 @@ fn run_sweep_k1(cfg: &MAGConfig, steps: usize, lr: f32, seed: u64) -> SweepResul
             nan_step = Some(step);
         }
 
-        if step > 0 && step % 25_000 == 0 {
+        if step > 0 && step % 25_000 == 0 && step < steps {
             milestones.push((step, loss));
         }
 


### PR DESCRIPTION
## Summary
- Expands stability sweep from 34 → **72 tests** (100K steps each at d=8)
- Covers all 8 MIRAS rules × 3 composition patterns (MAG/MAL/MAC) × 3 CMS levels (k=1/k=2/k=4)
- **0% degenerate dynamics** (0/72) — well under spec's 20% falsification threshold
- MAC+CMS combos use `lr=0.001` (error buffer flush is aggressive); all others use `lr=0.01`

## Test plan
- [x] All 72 sweep tests pass (72/72, ~16s total)
- [x] Full regression passes (590 Rust tests, 0 failures)
- [x] No source changes — test file only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive 100K-step stability sweep test suite exercising multiple memory rules, compositions (MAG/MAL/MAC), and CMS configurations (k=1,2,4). Includes deterministic data, milestone logging, NaN/finiteness detection, convergence checks, and targeted learning-rate variations to validate numerical stability and loss improvements across many scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->