### PR TITLE
Complete S2-M1: multi-arch CUDA dispatch + build documentation

### DIFF
--- a/core/tests/test_dispatch.rs
+++ b/core/tests/test_dispatch.rs
@@ -1,0 +1,185 @@
+// Dispatch tests: Backend enum, GPU detection, backend selection, force override.
+//
+// Tests are split into:
+//   - Always-run: Backend enum, select_backend() logic (no GPU needed)
+//   - CUDA-only: detect_gpu(), force_rust_reference() with actual dispatch
+
+use nl_hecate_core::dispatch::{Backend, GpuInfo, select_backend, force_rust_reference, is_rust_forced, detect_gpu};
+
+// ══════════════════════════════════════════════════════════════════════
+// Backend enum tests (always run)
+// ══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_backend_variants() {
+    let r = Backend::RustReference;
+    let n = Backend::CudaNative;
+    let p = Backend::CudaPtx;
+
+    // Debug + PartialEq work
+    assert_eq!(r, Backend::RustReference);
+    assert_ne!(r, n);
+    assert_ne!(n, p);
+    assert_eq!(format!("{:?}", r), "RustReference");
+    assert_eq!(format!("{:?}", n), "CudaNative");
+    assert_eq!(format!("{:?}", p), "CudaPtx");
+}
+
+#[test]
+fn test_backend_copy_clone() {
+    let b = Backend::CudaNative;
+    let b2 = b; // Copy
+    let b3 = b.clone(); // Clone
+    assert_eq!(b, b2);
+    assert_eq!(b, b3);
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Backend selection logic (no GPU needed)
+// ══════════════════════════════════════════════════════════════════════
+
+fn make_gpu(name: &str, major: i32, minor: i32) -> GpuInfo {
+    GpuInfo {
+        name: name.to_string(),
+        compute_major: major,
+        compute_minor: minor,
+        sm_version: major * 10 + minor,
+    }
+}
+
+#[test]
+fn test_select_backend_no_gpu() {
+    assert_eq!(select_backend(&None), Backend::RustReference);
+}
+
+#[test]
+fn test_select_backend_sm86() {
+    let gpu = Some(make_gpu("RTX A6000", 8, 6));
+    assert_eq!(select_backend(&gpu), Backend::CudaNative);
+}
+
+#[test]
+fn test_select_backend_sm89() {
+    let gpu = Some(make_gpu("RTX 4090", 8, 9));
+    assert_eq!(select_backend(&gpu), Backend::CudaNative);
+}
+
+#[test]
+fn test_select_backend_sm90() {
+    let gpu = Some(make_gpu("H100", 9, 0));
+    assert_eq!(select_backend(&gpu), Backend::CudaNative);
+}
+
+#[test]
+fn test_select_backend_future_arch() {
+    // sm_100 — no explicit SASS, but PTX fallback covers it
+    let gpu = Some(make_gpu("Future GPU", 10, 0));
+    assert_eq!(select_backend(&gpu), Backend::CudaPtx);
+}
+
+#[test]
+fn test_select_backend_old_gpu() {
+    // sm_75 (Turing) — below minimum, no PTX compiled for it
+    let gpu = Some(make_gpu("RTX 2080", 7, 5));
+    assert_eq!(select_backend(&gpu), Backend::RustReference);
+}
+
+#[test]
+fn test_select_backend_sm80() {
+    // sm_80 (A100) — below minimum sm_86
+    let gpu = Some(make_gpu("A100", 8, 0));
+    assert_eq!(select_backend(&gpu), Backend::RustReference);
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// Force override tests (always run — tests the atomic flag)
+// ══════════════════════════════════════════════════════════════════════
+
+#[test]
+fn test_force_rust_reference_flag() {
+    // Reset to default
+    force_rust_reference(false);
+    assert!(!is_rust_forced());
+
+    force_rust_reference(true);
+    assert!(is_rust_forced());
+
+    force_rust_reference(false);
+    assert!(!is_rust_forced());
+}
+
+// ══════════════════════════════════════════════════════════════════════
+// GPU detection tests (CUDA only)
+// ══════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "cuda")]
+mod cuda_tests {
+    use super::*;
+    use nl_hecate_core::dispatch::delta_forward_dispatch;
+
+    #[test]
+    fn test_detect_gpu_returns_info() {
+        let gpu = detect_gpu();
+        assert!(gpu.is_some(), "Expected at least one GPU when compiled with --features cuda");
+    }
+
+    #[test]
+    fn test_gpu_info_fields() {
+        let gpu = detect_gpu().expect("No GPU detected");
+        assert!(!gpu.name.is_empty(), "GPU name should not be empty");
+        assert!(gpu.compute_major >= 8, "Expected compute major >= 8, got {}", gpu.compute_major);
+        assert!(gpu.sm_version >= 86, "Expected sm_version >= 86, got {}", gpu.sm_version);
+    }
+
+    #[test]
+    fn test_select_backend_real_gpu() {
+        let gpu = detect_gpu();
+        let backend = select_backend(&gpu);
+        // Our hardware is sm_86 and sm_89, both should be CudaNative
+        assert_eq!(backend, Backend::CudaNative,
+                   "Expected CudaNative for detected GPU {:?}", gpu);
+    }
+
+    #[test]
+    fn test_force_rust_overrides_cuda_dispatch() {
+        // Run a small Delta forward through CUDA, then force Rust and verify
+        // both paths produce the same result.
+        let d = 4;
+        let seq_len = 2;
+        let dd = d * d;
+        let k_mem = vec![0.1f32; seq_len * d];
+        let v_mem = vec![0.2f32; seq_len * d];
+        let q_mem = vec![0.05f32; seq_len * d];
+        let alpha = vec![0.01f32; seq_len];
+        let theta = vec![0.1f32; seq_len];
+        let m_initial = vec![0.0f32; dd];
+
+        // CUDA path
+        force_rust_reference(false);
+        let mut m_states_cuda = vec![0.0f32; (seq_len + 1) * dd];
+        let mut y_cuda = vec![0.0f32; seq_len * d];
+        delta_forward_dispatch(
+            &k_mem, &v_mem, &q_mem, &alpha, &theta, &m_initial,
+            &mut m_states_cuda, &mut y_cuda, seq_len, d,
+        );
+
+        // Force Rust path
+        force_rust_reference(true);
+        let mut m_states_rust = vec![0.0f32; (seq_len + 1) * dd];
+        let mut y_rust = vec![0.0f32; seq_len * d];
+        delta_forward_dispatch(
+            &k_mem, &v_mem, &q_mem, &alpha, &theta, &m_initial,
+            &mut m_states_rust, &mut y_rust, seq_len, d,
+        );
+
+        // Reset
+        force_rust_reference(false);
+
+        // Both should produce very close results (< 1e-5 per element)
+        for i in 0..y_cuda.len() {
+            let diff = (y_cuda[i] - y_rust[i]).abs();
+            assert!(diff < 1e-5,
+                    "y[{i}] CUDA={} Rust={} diff={}", y_cuda[i], y_rust[i], diff);
+        }
+    }
+}

--- a/docs/build_matrix.md
+++ b/docs/build_matrix.md
@@ -1,0 +1,150 @@
+# NL_Hecate Build Matrix
+
+## Toolchain Requirements
+
+| Component | Version | Notes |
+|---|---|---|
+| Rust toolchain | `enzyme` (nightly, rustc d7daac06) | Custom-built with `llvm.enzyme = true` |
+| LLVM | 20.0+ (built from source with Enzyme) | Ships with the `enzyme` toolchain |
+| CUDA Toolkit | 12.8+ | Required for `cuda` feature only |
+| nvcc | Matches CUDA Toolkit version | Compiles `.cu` to fat binary |
+| cc crate | 1.0+ | Drives nvcc from `build.rs` |
+
+**Toolchain location**: `/home/todd/olympus/rust-enzyme/`
+**Linked as**: `rustup toolchain link enzyme build/x86_64-unknown-linux-gnu/stage1`
+
+## Feature Combinations
+
+| Features | Target | Enzyme AD | CUDA | WASM | Use Case |
+|---|---|---|---|---|---|
+| (none) | x86_64 | No | No | No | Rust reference only |
+| `cuda` | x86_64 + sm_86/89/90 | No | Yes | No | GPU-accelerated kernels |
+| `enzyme` | x86_64 | Yes | No | No | AD-enabled gradient tests |
+| `edge` | x86_64, wasm32 | No | No | Yes | Micro model deployment |
+| `cuda,enzyme` | x86_64 + sm_86/89/90 | Yes | No | No | Full pipeline (Enzyme + CUDA) |
+| `cuda,distributed` | x86_64 + sm_86/89/90 | No | Yes | No | Multi-GPU training |
+| `cuda,serving` | x86_64 + sm_86/89/90 | No | Yes | No | Production inference |
+| `cuda,distributed,serving` | x86_64 + sm_86/89/90 | No | Yes | No | Full production |
+
+## GPU Architecture Support
+
+The CUDA build produces a **fat binary** containing multiple architecture variants. The CUDA runtime automatically selects the correct one at kernel launch time.
+
+| Architecture | GPU Examples | Binary Type | Performance |
+|---|---|---|---|
+| sm_86 | RTX A6000, RTX 3090, RTX 3080 | SASS (native) | Optimal |
+| sm_89 | RTX 4090, RTX 2000 Ada, L40 | SASS (native) | Optimal |
+| sm_90 | H100, H200 | SASS (native) | Optimal |
+| sm_86+ (other) | Future GPUs | PTX (JIT-compiled) | Near-optimal (first-launch JIT cost) |
+| < sm_86 | V100, A100, RTX 2080 | Not supported | Falls back to Rust reference |
+
+### How Fat Binary Works
+
+`build.rs` passes multiple `-gencode` flags to nvcc:
+
+```
+-gencode arch=compute_86,code=sm_86     # SASS for sm_86
+-gencode arch=compute_89,code=sm_89     # SASS for sm_89
+-gencode arch=compute_90,code=sm_90     # SASS for sm_90
+-gencode arch=compute_86,code=compute_86  # PTX for JIT fallback
+```
+
+The `cc` crate packages all variants into a single `.o` file linked into the Rust binary. No separate `.cubin` or `.ptx` file management needed.
+
+## Build Commands
+
+### Rust Reference Only (no GPU, no Enzyme)
+
+```bash
+cargo +enzyme build --release
+cargo +enzyme test --release --lib --tests
+```
+
+### CUDA Build (requires GPU + CUDA Toolkit)
+
+```bash
+cargo +enzyme build --release --features cuda
+cargo +enzyme test --release --features cuda --lib --tests
+```
+
+### Enzyme AD Build (requires nightly with autodiff)
+
+```bash
+RUSTFLAGS="-Zautodiff=Enable" cargo +enzyme build --release --features enzyme
+RUSTFLAGS="-Zautodiff=Enable" cargo +enzyme test --release --features enzyme --lib --tests
+```
+
+### Full Build (all features)
+
+```bash
+RUSTFLAGS="-Zautodiff=Enable" cargo +enzyme test --release \
+  --features "cuda,distributed,serving,edge,enzyme" \
+  --lib --tests
+```
+
+### Edge / WASM Build
+
+```bash
+# x86_64 edge
+cargo +enzyme build --release --features edge
+
+# wasm32 cross-compile validation
+cargo +enzyme build --release --features edge --target wasm32-unknown-unknown --lib
+```
+
+## Runtime Backend Selection
+
+The dispatch system uses **compile-time** feature gates as the primary mechanism (zero overhead). An optional **runtime** override exists for testing:
+
+```rust
+use nl_hecate_core::dispatch::{detect_gpu, select_backend, force_rust_reference};
+
+// Query GPU at startup (diagnostics/logging)
+let gpu = detect_gpu();
+let backend = select_backend(&gpu);
+println!("Backend: {:?}, GPU: {:?}", backend, gpu);
+
+// Force Rust path for comparison testing
+force_rust_reference(true);
+// ... all dispatch functions now use Rust reference ...
+force_rust_reference(false);
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `CUDA_PATH` | `/usr/local/cuda-12.8` | CUDA Toolkit installation path |
+| `RUSTFLAGS` | (none) | Set to `-Zautodiff=Enable` for Enzyme |
+
+## Known Limitations
+
+1. **Fat LTO mandatory**: `lto = "fat"` in `Cargo.toml` is required for Enzyme. This increases link time but is non-negotiable.
+2. **sm < 86 unsupported**: GPUs older than Ampere fall back to Rust reference. No PTX is emitted for compute < 86.
+3. **head_dim <= 32 for SWA CUDA**: The SWA kernel uses one warp per (head, position). Larger head_dim requires multi-warp reduction (not implemented).
+4. **Single-block memory kernels**: Delta/Titans/Hebbian kernels use Grid=1, Block=min(d^2, 1024). This is optimal for small d but doesn't parallelize across the sequence dimension.
+5. **Enzyme + CUDA**: Enzyme differentiates the Rust code only. CUDA kernels are opaque (nvcc produces SASS, not LLVM IR). Gradients for CUDA operations use hand-written backward kernels.
+
+## Kernel Inventory
+
+| Kernel File | Operation | Precision | Grid | Block |
+|---|---|---|---|---|
+| `swa_forward.cu` | SWA attention forward | bf16 storage, f32 compute | (num_heads, seq_len) | (head_dim) |
+| `swa_backward.cu` | SWA attention backward | bf16 inputs, f32 grads | (num_heads, seq_len) | (head_dim) |
+| `delta_forward.cu` | Delta Rule M recurrence | all f32 | (1) | min(d*d, 1024) |
+| `delta_backward.cu` | Delta Rule gradients | all f32 | (1) | min(d*d, 1024) |
+| `titans_forward.cu` | Titans LMM M+S recurrence | all f32 | (1) | min(d*d, 1024) |
+| `titans_backward.cu` | Titans LMM gradients | all f32 | (1) | min(d*d, 1024) |
+| `hebbian_forward.cu` | Hebbian M recurrence | all f32 | (1) | min(d*d, 1024) |
+| `hebbian_backward.cu` | Hebbian gradients | all f32 | (1) | min(d*d, 1024) |
+
+## Test Counts
+
+| Test File | Tests | Feature Gate |
+|---|---|---|
+| `test_cuda_swa.rs` | 5 | `cuda` |
+| `test_cuda_delta.rs` | 11 | `cuda` |
+| `test_cuda_titans.rs` | 6 | `cuda` |
+| `test_cuda_hebbian.rs` | 7 | `cuda` |
+| `test_cuda_compositions.rs` | 5 | `cuda` |
+| `test_dispatch.rs` | ~13 | partial `cuda` |


### PR DESCRIPTION
## Summary

- **Multi-arch fat binary**: `build.rs` now compiles for sm_86 (A6000), sm_89 (RTX 4090/Ada), sm_90 (H100) plus PTX fallback for future GPUs >= sm_86
- **Backend detection**: `Backend` enum, `GpuInfo` struct, `detect_gpu()`, `select_backend()` for runtime diagnostics and logging
- **Force override**: `force_rust_reference()` lets tests/debugging bypass CUDA even when compiled in — Rust reference inner loops always compiled now (not cfg-gated away)
- **Build matrix docs**: `docs/build_matrix.md` covers toolchain, feature combinations, GPU architecture support, build commands, kernel inventory
- **ROADMAP**: S2-M1 and Stage 2 marked fully complete

## Test plan

- [x] 14 new dispatch tests pass (10 non-CUDA + 4 CUDA)
- [x] 34 existing CUDA kernel tests pass (zero regression)
- [x] Multi-arch build compiles successfully (sm_86 + sm_89 + sm_90 + PTX)
- [x] `detect_gpu()` returns valid GpuInfo on CUDA builds
- [x] `force_rust_reference()` correctly overrides CUDA dispatch
- [x] 6 MAL gradient failures confirmed pre-existing (identical on unmodified main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended NVIDIA GPU architecture support with intelligent fallback selection
  * Added runtime backend override mechanism for performance tuning and testing

* **Documentation**
  * New comprehensive build matrix covering toolchain requirements, feature combinations, and compilation configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->