### PR TITLE
S4-M8 PR2: BPE masking + BpeDataLoader

### DIFF
--- a/python/configs/sharegpt_32k.json
+++ b/python/configs/sharegpt_32k.json
@@ -1,0 +1,31 @@
+{
+    "description": "ShareGPT conversational training — 32K BPE, Titans MAG k=4",
+    "model": {
+        "d_model": 1024,
+        "num_heads": 16,
+        "head_dim": 64,
+        "seq_len": 512,
+        "window_size": 256,
+        "vocab_size": 32000,
+        "memory_rule": "titans",
+        "composition": "mag",
+        "k": 4,
+        "chunk_sizes": [1, 8, 64, 512]
+    },
+    "build": {
+        "lr": 0.0003,
+        "optimizer": "adamw_gpu",
+        "warmup_steps": 500,
+        "steps": 100000,
+        "save_every": 5000,
+        "log_every": 50,
+        "max_grad_norm": 1.0,
+        "weight_decay": 0.1,
+        "save_path": "checkpoints/sharegpt_32k.json",
+        "log_file": "runs/sharegpt_32k.jsonl"
+    },
+    "data": {
+        "path": "data/sharegpt",
+        "format": "sharegpt"
+    }
+}


### PR DESCRIPTION
## Summary
- Fix GPU forward/backward loss normalization to divide by valid target count (not seq_len), supporting masked targets
- Remove target_ids >= vocab validation from PyO3 GpuModel methods — CUDA kernel safely skips invalid targets
- Add `BpeDataLoader` class: loads numpy token/target arrays, serves chunks with -1 → vocab_size masking
- Add `data_format: "sharegpt"` config support with auto vocab_size from meta.json
- Add `configs/sharegpt_32k.json`: 90M param Titans MAG k=4 for 100K steps

## Test plan
- [x] 676 Rust core tests pass (masking normalization is backward-compatible with byte-level)
- [x] 100-step GPU smoke test with ShareGPT data: loss=10.37→10.37 (warmup phase), no NaN
- [x] Initial loss = ln(32000) = 10.37 — confirms correct normalization over valid tokens only
- [x] GPU memory fits in 48GB A6000

🤖 Generated with [Claude Code](https://claude.com/claude-code)