### PR TITLE
P1.10: Class 2 FD correctness tests for all TapeOp variants

### DIFF
--- a/core/src/tape.rs
+++ b/core/src/tape.rs
@@ -1807,7 +1807,7 @@ mod tests {
             let mut out = vec![0.0f32; xp.len()];
             for s in 0..m_slots {
                 let slot = &xp[s * d..(s + 1) * d];
-                let norm = slot.iter().map(|v| v * v).sum::<f32>().sqrt().max(1.0);
+                let norm = slot.iter().map(|v| v * v).sum::<f32>().sqrt().max(1e-8);
                 for i in 0..d {
                     out[s * d + i] = slot[i] / norm;
                 }


### PR DESCRIPTION
## Summary
- 25 finite-difference tests covering every non-Opaque TapeOp variant
- 11 new tests: MatmulTransposeB, Transpose, Add, Sub, Mul, Scale, Negate, SumReduce, Concat, Slice, StraightThroughBool
- Fixes closure move error in existing OuterProduct FD test
- Adds SumReduce op + backward (needed as loss reduction for all FD tests)
- Phase 1 gate: Class 1 (isolation) + Class 2 (FD correctness) both satisfied

## Test plan
- [x] All 25 FD tests pass (central differences eps=1e-2, rel_tol=10%, abs_threshold=5e-4)
- [x] STE property verified for StraightThroughBool (gradient == 1.0 pass-through)
- [x] Full lib test suite: 746/746 pass (740 existing + 6 net new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SumReduce operation for computing input tensor sums with automatic gradient support.

* **Tests**
  * Expanded test coverage across operators including matrix operations, activation functions, normalization, and more to enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->