### PR TITLE
P3.2: Frozen-level error buffer routing in tape_compute_gradients

### DIFF
--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -336,8 +336,10 @@ pub fn tape_compute_gradients(
                 level_grads.push(lp_grad);
             } else {
                 // Frozen level: route gradient into error buffer, return zeros.
+                // Use zeros_like_from to match lp_grad's shape (includes w_freq/b_freq
+                // when FrequencySchedule::Learned is active).
                 error_buffers[level].accumulate(&lp_grad);
-                level_grads.push(MemoryLevelParams::zeros_like(d));
+                level_grads.push(MemoryLevelParams::zeros_like_from(&lp_grad, d));
             }
         }
 


### PR DESCRIPTION
## Summary
- Route frozen CMS level gradients to `error_buffers[level]` in `tape_compute_gradients()`, matching existing `cms_backward()` semantics
- Active levels return gradients directly in `MAGParams`; frozen levels return zeros and accumulate in `ErrorBuffer`
- Added test with memory warm-up (all-active forward pass populates M before testing frozen backward — zero M produces trivially zero gradients)

## Changes
- `core/src/gradient.rs`: Active/frozen routing logic, `MemoryLevelParams` import, test with warm-up pattern

## Test plan
- [x] New test `test_tape_frozen_level_routes_to_error_buffer` passes (bitwise loss match, error buffer nonzero, returned grads zero)
- [x] 790/790 lib tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure gradients from frozen memory levels are routed into error buffers while active-level gradients are returned, aligning per-level gradient behavior across paths.

* **Tests**
  * Added tests validating frozen-level gradients route to error buffers and that returned gradients for frozen levels are zeroed.

* **Documentation**
  * Clarified comments to reflect the updated gradient routing semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->