### PR TITLE
P3.4: Class 3 tests — tape vs hand-written backward

### DIFF
--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -5762,6 +5762,7 @@ mod tests {
     /// Run tape_compute_gradients and cms_compute_gradients on the same config,
     /// assert loss is bitwise equal and all parameter gradients match within tolerance.
     fn class3_tape_vs_handwritten(cfg: &MAGConfig, label: &str) {
+        ensure_rust_reference();
         let d = cfg.swa.d_model;
         let s = cfg.swa.seq_len;
         let v = cfg.swa.vocab_size;
@@ -5963,6 +5964,7 @@ mod tests {
 
     #[test]
     fn test_class3_delta_k2_frozen() {
+        ensure_rust_reference();
         let cfg = MAGConfig::test_config_k2();
         let d = cfg.swa.d_model;
         let s = cfg.swa.seq_len;


### PR DESCRIPTION
## Summary

- 20 new Class 3 tests validating `tape_compute_gradients()` produces identical gradients to `cms_compute_gradients()` (hand-written backward)
- All 9 memory rules tested at k=1 and k=2: DeltaRule, TitansLMM, Hebbian, MONETA, YAAD, MEMORA, LatticeOSR, Trellis, AtlasOmega
- Additional tests: DeltaRule k=4 and DeltaRule k=2 with frozen level 1
- Tolerance: rtol=1e-5, atol=1e-6 (tight — validates exact VJP composition)
- Frozen test verifies error buffer routing matches between tape and hand-written paths

## Test plan

- [x] 20 new Class 3 tests pass (`cargo test --lib test_class3`)
- [x] Full suite: 812/812 pass (`cargo test --lib`)
- [x] No regressions in existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tape-vs-handwritten backward-gradient verification across many model variants and mixed active/frozen scenarios.
  * Introduced elementwise gradient comparator with strict tolerances (rtol=1e-5, atol=1e-6) and a test harness that runs both backward paths and compares loss and gradient slices.
  * Added diagnostic mismatch reporting and a final assertion ensuring zero element mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->