### PR TITLE
P4.1: Switch cms_compute_gradients to tape path

### DIFF
--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -286,6 +286,8 @@ pub fn cms_compute_gradients_handwritten(
     context: &mut ContextState,
     error_buffers: &mut [ErrorBuffer],
 ) -> (f32, MAGParams) {
+    debug_assert_eq!(error_buffers.len(), cfg.k,
+        "error_buffers length ({}) must equal cfg.k ({})", error_buffers.len(), cfg.k);
     let (loss, cache) = cms_forward(params, cfg, input_ids, target_ids, pulse, context);
     let grads = cms_backward(params, cfg, &cache, input_ids, target_ids, error_buffers);
     (loss, grads)


### PR DESCRIPTION
## Summary

- `cms_compute_gradients()` now delegates to `tape_compute_gradients()` (Wengert tape)
- Hand-written backward preserved as `cms_compute_gradients_handwritten()` for test oracle use
- Same signature, same return type — zero API change for callers
- Class 3 tests updated to use renamed `_handwritten` function
- All 200+ existing FD tests now exercise the tape path against finite differences

## Test plan

- [x] Full suite: 833/833 pass (`cargo test --lib`)
- [x] All FD tests pass (tape gradients match finite differences)
- [x] Class 3 tests pass (tape matches hand-written oracle)
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded gradient validation tests to include a preserved handwritten reference path as an oracle to verify parity with the main (tape-based) gradient path.

* **Refactor**
  * Reworked gradient computation flow to delegate to the tape-based implementation while keeping the handwritten path for reference and improved maintainability and testability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->