### PR TITLE
P4.2: Build loop regression test — 10-step trajectory

### DIFF
--- a/core/src/gradient.rs
+++ b/core/src/gradient.rs
@@ -6369,6 +6369,8 @@ mod tests {
                 .chain(level.w_eta.iter())
                 .chain(level.b_eta.iter())
                 .chain(level.w_omega.iter())
+                .chain(level.w_freq.iter())
+                .chain(level.b_freq.iter())
             {
                 sum += g * g;
             }


### PR DESCRIPTION
## Summary
- Adds a 10-step build loop regression test comparing tape gradient path vs hand-written backward path
- DeltaRule k=2 on tiny model (d=8, vocab=16, seq=8) with Conductor generating CMS pulses
- Verifies loss and gradient norms match at every step within f32 tolerance (rel_tol=1e-5)
- Confirms outer loop works: loss decreases steadily across all 10 steps
- 834/834 tests pass (833 existing + 1 new)

## Test plan
- [x] New test `test_build_loop_regression_delta_k2` passes
- [x] Full `cargo test --lib` — 834 pass, 0 fail
- [x] Loss trajectory identical between tape and hand-written paths
- [x] Gradient norm trajectory identical between both paths
- [x] Loss decreases over 10 steps (outer loop validated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added multi-step regression tests that run a 10-step build loop to verify consistency between two gradient computation paths.
  * Checks include exact match at step 0, relative closeness of losses and gradient norms on subsequent steps, and a helper to compare gradient L2 norms across parameter sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->