### PR TITLE
P4.3: PyO3 binding for tape-based CMS gradients

### DIFF
--- a/python/build.py
+++ b/python/build.py
@@ -724,11 +724,10 @@ def main():
             gpu_model.upload_params(params)
             error_buffers.apply_for_active(params, pulse, current_lr)
         else:
-            # CPU path: forward + backward + update separately
-            loss, cache = nl_hecate.cms_forward(
-                params, cfg, input_ids, target_ids, pulse, context)
-            grads = nl_hecate.cms_backward(
-                params, cfg, cache, input_ids, target_ids, error_buffers)
+            # CPU path: tape-based forward + backward (single call)
+            loss, grads = nl_hecate.cms_compute_gradients(
+                params, cfg, input_ids, target_ids, pulse, context,
+                error_buffers)
             if adamw_opt:
                 p_flat = params.get_flat_weights()
                 g_flat = grads.get_flat_weights()


### PR DESCRIPTION
## Summary
- Adds `cms_compute_gradients()` Python binding that calls the Rust tape-backed path
- Updates `build.py` CPU path to use the combined function instead of separate `cms_forward` + `cms_backward`
- GPU path (`GpuModel.step`/`step_adamw`) unchanged — still uses `gpu_cms_backward` with hand-written CUDA kernels
- No Python API breakage — `cms_forward` and `cms_backward` remain available for direct use

## Test plan
- [x] 27/27 Python tests pass (`test_bindings`, `test_training`, `test_baseline`)
- [x] 834/834 Rust lib tests pass
- [x] New binding accepts same args as `cms_forward` + `cms_backward` combined
- [x] `build.py` CPU path uses tape gradient path

🤖 Generated with [Claude Code](https://claude.com/claude-code)