### PR TITLE
S3b-S2: Spec DMGD (Deep Momentum Gradient Descent)

### DIFF
--- a/specs/algorithms/optimization_machinery/04_dmgd.md
+++ b/specs/algorithms/optimization_machinery/04_dmgd.md
@@ -160,6 +160,7 @@ mirrors the memory rule upgrade: Hebbian → Delta → Titans (MLP).
 
 DMGD and DGD operate at different levels:
 
+<!-- HADES: hope_equations/eq-088-practical-dgd-update (§8.1 Eq 88, DGD); hope_equations/eq-049-l2-momentum-update (§4.4 Eq 49, Delta Momentum) -->
 ```text
 -- DGD: upgrades the MEMORY update (inner loop)
 --   M_{t+1} = (1-alpha) * M - theta * (M@k - v) @ k^T
@@ -176,6 +177,7 @@ DMGD and DGD operate at different levels:
 
 When DGD composes with Delta Momentum (the combination used in practice):
 
+<!-- HADES: Composite of hope_equations/eq-121-delta-gd-final (Appendix C Eq 121) + hope_equations/eq-049-l2-momentum-update (§4.4 Eq 49) -->
 ```text
 FUNCTION: dgd_with_delta_momentum(M: &mut Tensor, S: &mut Tensor,
                                    k: &Tensor, v: &Tensor,


### PR DESCRIPTION
## Summary
- Adds CONTRACT-format spec for DMGD (Deep Momentum Gradient Descent) from HOPE paper §4.2-4.4
- Covers the full momentum expressiveness hierarchy: EMA → Delta Momentum → Deep Momentum (MLP) → feature maps → nonlinear outputs (Muon)
- Delta Momentum replaces the Hebbian objective with L2 regression, making momentum state-dependent via the `(alpha - g^T g)` decay term
- Includes analytical backward gradients for tape integration, interaction with DGD (double state-dependence), and HADES traceability on all equation blocks

## Test plan
- [ ] Spec reviewed for correctness against HOPE (2512.24695) §4.2-4.4, Eqs 33-53
- [ ] Delta Momentum update (Eq 49) cross-checked: gradient-dependent decay term
- [ ] DMGD MLP formulation (Eq 50) verified
- [ ] Analytical gradients for Delta Momentum backward pass reviewed
- [ ] Hierarchy table matches paper progression (Eqs 32→33→49→50→51→52)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Deep Momentum Gradient Descent (DMGD) guide covering momentum variants and expressiveness hierarchy, formal update equations, state- and gradient-dependent behaviors, interaction with existing momentum methods, forward/backward and tape-based derivations, chunk-wise parallelization strategy, initialization and numerical-safety recommendations, preconditioning and cost estimates, ablation findings, and a practical implementation roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->