### PR TITLE
S3b-S3: Spec FTRL (Follow the Regularized Leader)

### DIFF
--- a/specs/algorithms/optimization_machinery/05_ftrl.md
+++ b/specs/algorithms/optimization_machinery/05_ftrl.md
@@ -263,6 +263,6 @@ structure (sparsity from L1, bounded norms from constraints), or
 
 ## Axiom Compliance
 
-- **NL IS #4** (compressing context): FTRL compresses the full gradient history into a regularized optimum.
-- **NL IS #6** (optimizers are associative memory): FTRL makes explicit that the memory update is an optimization problem, not just a heuristic.
-- **NL IS #9** (principled not ad hoc): FTRL provides regret bounds — the memory rule has provable online learning guarantees.
+- **NL IS #4** (compressing context): Compresses the full gradient history into a regularized optimum.
+- **NL IS #6** (optimizers are associative memory): Makes explicit that the memory update is an optimization problem, not just a heuristic.
+- **NL IS #9** (principled not ad hoc): Provides regret bounds — the memory rule has provable online learning guarantees.


### PR DESCRIPTION
## Summary
- Adds CONTRACT-format spec for FTRL (Follow the Regularized Leader) from MIRAS §3.2 and HOPE §2 Eq 3
- Documents the three equivalent viewpoints for deriving memory update rules (Online GD, FTRL, Learning-Retaining)
- Derives elastic net retention as an FTRL special case via soft thresholding (MIRAS Eq 23)
- Proves FTRL ↔ Learning-Retaining equivalence (Proposition 3.2) and positions FTRL as the theoretical umbrella over GD/DGD
- Includes analytical gradients for both quadratic and elastic net FTRL, plus HADES traceability on all equation blocks

## Test plan
- [ ] Spec reviewed for correctness against MIRAS (2504.13173) §3.2, Eq 7, Proposition 3.2
- [ ] FTRL general form (eq-vp-ftrl-general) cross-checked with paper
- [ ] Elastic net derivation (Eq 23) verified: accumulate + soft threshold
- [ ] Proposition 3.2 equivalence statement matches paper proof
- [ ] Algorithm comparison table consistent with DGD and DMGD specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation of the Follow the Regularized Leader (FTRL) optimization framework: multiple equivalent formulations, conditions for equivalence, practical elastic‑net instantiation, gradient/backprop considerations (including handling of non‑differentiable steps), parallelization strategies, implementation guidance, and comparison of tuning knobs to aid application and integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->