### PR TITLE
S3b-S5: Spec Newton-Schulz iteration (inner-loop preconditioner)

### DIFF
--- a/specs/algorithms/optimization_machinery/07_newton_schulz_inner.md
+++ b/specs/algorithms/optimization_machinery/07_newton_schulz_inner.md
@@ -16,7 +16,7 @@ CONTRACT
               The iteration is purely matrix multiplications — no eigendecomposition.
   Cost:       Per iteration: O(d^3) — three matrix multiplications.
               k=5 iterations: 15 matmuls total. For d=64 (inner loop), this is
-              ~0.8M FLOPs per NS call. For d=2048 (outer loop), ~130G FLOPs.
+              ~4M FLOPs per NS call. For d=2048 (outer loop), ~130G FLOPs.
   Trade-off:  Better gradient geometry (locally optimal updates) at the cost of
               k extra matmul passes per step. The Atlas ablation shows this is
               worth it: Muon is the defining feature of Atlas vs OmegaNet.
@@ -171,6 +171,7 @@ M^(2)_t = M^(2)_t - beta_2 * sum_{i=t-C}^t g_i   -- slow: every C steps
 The backward pass through Newton-Schulz requires differentiating the
 iterative process:
 
+<!-- HADES: Derived from hope_equations/eq-044-newton-schulz-iteration (§4.2 Eq 44), backward through unrolled iteration -->
 ```text
 -- Forward: O_k = NS_k(G)  (k iterations of the NS recurrence)
 -- The iteration is a composition of differentiable matrix operations.
@@ -222,6 +223,6 @@ iterative process:
 
 ## Axiom Compliance
 
-- **NL IS #6** (optimizers are associative memory): NS orthogonalizes the memory write, making the update geometrically optimal.
-- **NL IS #7** (self-modifying): The NS output depends on the accumulated momentum state, adapting the update direction to gradient history.
-- **NL IS #9** (principled not ad hoc): NS is the exact solution to a well-defined orthogonalization objective (Eq 43), not a heuristic.
+- **NL IS #6** (optimizers are associative memory): Orthogonalizes the memory write, making the update geometrically optimal.
+- **NL IS #7** (self-modifying): Output depends on accumulated momentum state, adapting the update direction to gradient history.
+- **NL IS #9** (principled not ad hoc): Exact solution to a well-defined orthogonalization objective (Eq 43), not a heuristic.


### PR DESCRIPTION
## Summary
- Adds CONTRACT-format spec for Newton-Schulz orthogonalization from HOPE §4.2 Eqs 42-44 and Atlas §5 Eqs 32, 39-41
- Documents NS as the "locally optimal" upgrade that maps gradients/momentum into orthogonal space
- Covers all applications: Muon (outer-loop), Atlas (inner-loop), M3 (CMS-aware multi-scale), and nonlinear output sigma
- Parallelization: NS is embarrassingly parallel within chunks (each position independent)
- Two backward pass strategies: unrolled tape (recommended for k=5) vs implicit differentiation at convergence
- HADES traceability on all equation blocks

## Test plan
- [ ] NS iteration (Eq 44) cross-checked: 3-degree polynomial form matches paper
- [ ] Muon formulation (Eq 42) verified against Jordan et al. 2024
- [ ] Atlas memory update (Eq 32) and parallel training (Eqs 39-41) reviewed
- [ ] M3 two-level momentum (Eq 75) consistent with existing 02_m3.md spec
- [ ] Cost analysis reviewed: 15 matmuls for k=5, scaling with d^3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide on the Newton–Schulz inner-loop orthogonalization preconditioner for momentum and memory updates.
  * Describes the iterative NS procedure, polynomial form, convergence/conditioning notes, and parallel chunking strategies.
  * Provides integration guidance with optimization workflows, backpropagation through NS iterations, and implementation considerations (defaults, cost, batching).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->