### PR TITLE
S3b-S14: Higher-order feature maps phi(k)

### DIFF
--- a/specs/algorithms/self_referential/02_feature_maps.md
+++ b/specs/algorithms/self_referential/02_feature_maps.md
@@ -14,8 +14,9 @@ CONTRACT
               kernel-based memory (phi = random features, polynomial features,
               or learned transforms).
   Expects:    Key vector k_t [d, 1]. Feature map phi: R^d -> R^d_phi where
-              d_phi >= d (expansion) or d_phi = d (same-dimensional transform).
-              Memory state M [d, d_phi] (widened if d_phi > d).
+              d_phi is arbitrary (d_phi < d for compression, d_phi = d for
+              same-dimensional transform, or d_phi > d for expansion).
+              Memory state M [d, d_phi] (reshaped from [d, d] when d_phi != d).
   Guarantees: phi(k) replaces k in all memory operations: update, read, gradient.
               When phi = identity, all equations reduce to the standard (no
               feature map) case. The MIRAS 4-knob framework applies unchanged


### PR DESCRIPTION
## Summary
- Spec for higher-order feature maps from HOPE (2512.24695) §4.4 Eq 51, §2 Eq 5
- Six feature map types: identity, linear, random Fourier, polynomial, learned MLP, ELU
- Feature maps as preprocessing step orthogonal to MIRAS 4-knob framework
- Integration: k_t → phi(k_t) wherever key appears (update, read, gradient)
- Gradient flow through fixed vs learnable feature maps
- Connection to self-referential projections (composable: adaptive projection + feature map)
- Memory dimension change when d_phi != d

## Test plan
- [ ] Verify HADES traceability on all equation blocks
- [ ] Confirm identity feature map recovers standard (no phi) equations
- [ ] Validate feature map is orthogonal to MIRAS knobs (no knob interaction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added detailed specification for Higher-Order Feature Maps, including supported map types, computational costs, gradient propagation mechanics, system integration points, and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->