### PR TITLE
S3b-S15: Chunkwise training for self-referential Titans

### DIFF
--- a/specs/algorithms/self_referential/03_chunkwise_self_ref.md
+++ b/specs/algorithms/self_referential/03_chunkwise_self_ref.md
@@ -300,6 +300,11 @@ schedule in a layered manner:
    independently to each of the 6 component memories. With checkpointing,
    component memory states at chunk boundaries are recomputed during
    backward rather than stored — trading 6× compute for 6× memory savings.
+   **Caution (CS-48)**: Gradient checkpointing can degrade NL convergence
+   because CMS-aware gradient flow depends on exact intermediate states at
+   chunk boundaries. Recomputation introduces floating-point non-determinism
+   that compounds across CMS levels. Profile carefully before enabling —
+   the memory savings may not justify the convergence cost.
 
 ## Axiom Compliance
 


### PR DESCRIPTION
## Summary
- Spec for chunkwise parallelization of 6-component self-referential memories (HOPE §8.2 Eqs 90-93)
- Chunk-start gradient approximation: all tokens in chunk compute gradients from frozen M state
- Dot-product objective (Eq 92): gradient M-independent, fully parallelizable, zero approximation error
- L2 objective (Eq 93): chunk-start approximation with O(C * eta) bounded error
- Per-component update frequencies: different C_square per component (fast for k/v, slow for gates)
- Associative scan parallelization of DGD recurrence within chunks
- CMS interaction: two orthogonal frequency dimensions (CMS level + component chunk size)

## Test plan
- [ ] Verify HADES traceability on all equation blocks
- [ ] Confirm dot-product fast path has zero approximation error
- [ ] Validate DGD recurrence matches 01_chunkwise_gd.md scan form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New standalone specification for chunkwise self-referential training across six memory components. Describes frozen boundary snapshots for parallel gradient evaluation, sequential chunkwise memory updates, per-component update-frequency scheduling, dot-product and L2 objective behaviors (including error scaling), parallel-within-chunk execution patterns, interaction with multi-scale scheduling, and implementation considerations for efficient training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->