### PR TITLE
S3b-S16: Spec AdamW outer-loop optimizer

### DIFF
--- a/specs/algorithms/optimization_machinery/08_adamw_outer.md
+++ b/specs/algorithms/optimization_machinery/08_adamw_outer.md
@@ -186,7 +186,7 @@ FUNCTION: frequency_gated_step(opt: &mut FrequencyAwareAdamW,
 A subtle but critical detail: bias correction must use the level's own step
 count, not the global step.
 
-<!-- HADES: Derived from hope_equations/eq-013-momentum-argmin (§4.1 Eq 13), bias correction with level-local step count -->
+<!-- HADES: Derived from nl_optimizers/opt-adam (§4.2, bias correction); hope_equations/eq-071-arch-variant2 (§6 Eq 71, per-level gating) -->
 ```text
 -- Why level-local step count matters:
 --
@@ -242,6 +242,7 @@ When a CMS level is frozen, gradients accumulate in an error buffer managed
 by the Conductor. When the level fires, the accumulated gradient is passed
 to AdamW as a single batch:
 
+<!-- HADES: Derived from hope_equations/eq-071-arch-variant2 (§6 Eq 71, error accumulation for frozen levels) -->
 ```text
 -- Frozen level gradient handling:
 --


### PR DESCRIPTION
## Summary
- Documents AdamW as the standard NL outer-loop optimizer (HOPE §9.2)
- Covers NL reframing: Adam's two moments as associative memories (Eq 13, §4.1-4.2)
- Frequency-gated updates with per-CMS-level state and level-local bias correction (CS-27/28, Eq 71)
- Cosine annealing schedule, gradient accumulation for frozen levels, GPU implementation notes
- Interaction with M3 multi-scale momentum

## Test plan
- [ ] Verify CONTRACT header completeness and HADES traceability
- [ ] Check consistency with existing CS-27/28 constraints in `specs/constraints/code_smells/04_optimizer.md`
- [ ] Verify alignment with existing `python/build.py:AdamW` and `core/src/gpu_optimizer.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive AdamW outer-loop design: per-level moment buffers, level-local bias correction, frequency-gated updates, handling of gradients while levels are frozen, decoupled weight decay, and gradient accumulation.
  * Added learning-rate schedule (cosine annealing with warmup), optional per-level LR scaling, SWA integration notes, GPU implementation caveats, checkpoint/restore guidance, interaction details with Multi-Scale Momentum, default hyperparameters, gradient clipping, and compliance axioms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->