### PR TITLE
S3b-S17: Spec AdaMuon optimizer (Adam + Muon)

### DIFF
--- a/specs/algorithms/optimization_machinery/09_adamuon.md
+++ b/specs/algorithms/optimization_machinery/09_adamuon.md
@@ -1,6 +1,6 @@
 # AdaMuon (Adam + Muon)
 
-<!-- HADES: atlas_equations/eq-032-atlas-memory-muon (Atlas Eq 32); atlas_equations/eq-033-atlas-momentum (Atlas Eq 33); hope_equations/eq-042-muon-optimizer (§4.3 Eq 42); hope_equations/eq-044-newton-schulz-iteration (§4.3 Eq 44) -->
+<!-- HADES: atlas_equations/eq-032-atlas-memory-muon (Atlas Eq 32); atlas_equations/eq-033-atlas-momentum (Atlas Eq 33); hope_equations/eq-042-muon-optimizer (§4.3 Eq 42); hope_equations/eq-044-newton-schulz-iteration (§4.3 Eq 44, cost: k_ns matrix multiplies of d×d) -->
 ```text
 CONTRACT
   Purpose:    AdaMuon combines Adam's per-element second-moment estimate with
@@ -63,7 +63,7 @@ FUNCTION: newton_schulz_k(S: &Tensor, k: usize) -> Tensor
   -- Maps momentum matrix to nearest orthogonal matrix
   -- Solves: min_X ||X^T X - I||_F  subject to column space of X = column space of S
   X = S / max(frobenius_norm(S), eps)   -- initial normalization
-  FOR iter in 0..k:
+  FOR iter = 0 to k-1:
     X = 0.5 * X @ (3 * I - X^T @ X)
   return X
 


### PR DESCRIPTION
## Summary
- Documents AdaMuon as the expressive outer-loop optimizer (Adam second moment + Muon Newton-Schulz orthogonalization)
- Covers Muon mechanics (HOPE Eqs 42-44), Atlas inner-loop usage (Eqs 32-33), and the combined AdaMuon update
- Frequency-gated CMS integration with cost amortization for slow levels
- Parameter group strategy: AdaMuon for matrix params, Adam for biases
- Interaction with M3 multi-scale momentum

## Test plan
- [ ] Verify CONTRACT header and HADES traceability on all equation blocks
- [ ] Check consistency with `01_momentum.md` Newton-Schulz section
- [ ] Check consistency with `05_atlas_parallel.md` Atlas Eqs 32-33
- [ ] Verify alignment with `08_adamw_outer.md` frequency gating pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive AdaMuon specification describing a dual-preconditioning optimizer combining orthogonalized momentum with per-element scaling.
  * Provides hyperparameter defaults, per-parameter grouping guidance (matrix vs bias handling), frequency-gating/outer-loop usage patterns, and convergence/memory considerations.
  * Notes on gradient-through policy, implementation status, and integration guidance for inner/outer-loop training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->