### PR TITLE
Complete hecate_specs graph coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ When writing or modifying a spec file in `specs/`, the corresponding HADES graph
 
 **Verification** (should return only infra-only specs like `edge_deployment`, `wengert_tape`):
 ```bash
-hades --db NL db aql "
+hades --database NL db aql "
   FOR s IN hecate_specs
     LET edges = (
       FOR e IN nl_hecate_trace_edges


### PR DESCRIPTION
## Summary
- Inserts 21 missing spec nodes into `hecate_specs` collection (70 total, full coverage)
- Creates 111 trace edges linking new specs to paper equations (333 total edges)
- Labels all 222 original edges with `rel: implements` or `rel: cites`
- Creates named graph `hecate_knowledge_graph` with 5 edge definitions
- Adds Graph Maintenance section to CLAUDE.md documenting ingestion policy for future specs

## Context
Task `task_4932df` — the HADES knowledge graph had 49 spec nodes but the repo has 70 spec files. This PR closes the gap and establishes policy so it stays current.

## Verification
```bash
hades --db NL db aql "RETURN LENGTH(hecate_specs)"  # → 70
hades --db NL db aql "FOR s IN hecate_specs LET edges = (FOR e IN nl_hecate_trace_edges FILTER e._from == CONCAT('hecate_specs/', s._key) RETURN 1) FILTER LENGTH(edges) == 0 RETURN s._key"
# → ["edge_deployment", "wengert_tape"] (infra specs with no paper equations — expected)
```

## Test plan
- [x] All 21 spec nodes inserted with correct schema
- [x] 111 trace edges created with `rel: "implements"`
- [x] Verification queries pass (70 specs, only infra-only specs lack edges)
- [x] Named graph traversable
- [x] CLAUDE.md documents maintenance policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Graph Maintenance (HADES Spec Ingestion)" section with per-event guidance for spec creation and updates, relationship mapping, insertion examples, and verification steps.
  * Expanded the cross-paper collection (hecate_specs) to reflect increased coverage (count updated from 48 to 70).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->