### PR TITLE
Add persistent tokens to MAL, document residual deviation

### DIFF
--- a/core/src/mal.rs
+++ b/core/src/mal.rs
@@ -323,6 +323,9 @@ pub fn mal_backward(
     // Reconstruct qkv_input for weight gradients
     let mut qkv_input = vec![0.0f32; s_total * d];
     if n_p > 0 {
+        assert_eq!(params.persistent_tokens.len(), n_p * d,
+            "persistent_tokens length mismatch: expected {} got {}",
+            n_p * d, params.persistent_tokens.len());
         qkv_input[..n_p * d].copy_from_slice(&params.persistent_tokens);
     }
     qkv_input[n_p * d..].copy_from_slice(&cache.attn_input);
@@ -745,6 +748,9 @@ pub fn cms_mal_backward(
     // ── Stage 3: QKV projection backward (inputs are [persistent | attn_input]) ──
     let mut qkv_input = vec![0.0f32; s_total * d];
     if n_p > 0 {
+        assert_eq!(params.persistent_tokens.len(), n_p * d,
+            "persistent_tokens length mismatch: expected {} got {}",
+            n_p * d, params.persistent_tokens.len());
         qkv_input[..n_p * d].copy_from_slice(&params.persistent_tokens);
     }
     qkv_input[n_p * d..].copy_from_slice(&cache.attn_input);


### PR DESCRIPTION
## Summary
- Add persistent token prepend to MAL forward/backward (single-level and CMS paths), following the same pattern as MAC PR #98
- Persistent tokens are prepended to `[persistent | attn_input]` before QKV/SWA, then stripped from output
- Document the intentional residual deviation: `attn_input = m_t + embedded` breaks bootstrapping deadlock (spec prescribes strict info bottleneck where attention only sees memory output)
- `n_persistent=0` (default) produces identical behavior to pre-change code

## Test plan
- [x] 5 new persistent token tests (forward finite, differs from no-persistent, backward finite, backward has gradient, zero matches original)
- [x] All 946 lib tests pass
- [x] All integration tests pass (0 failures)

Closes PS-TB-03 (task_84b4ec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent-token support added to attention, prepending persistent tokens so they influence outputs and training.

* **Updates**
  * Forward/backward flows and public caches updated to handle extended sequence lengths and propagate gradients into persistent tokens; residual bootstrapping behavior preserved.

* **Tests**
  * Added tests validating forward/backward behavior, gradient propagation for persistent tokens, and parity when none are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->