### PR TITLE
Implement FTRL accumulator state pattern with STE backward

### DIFF
--- a/core/src/retention.rs
+++ b/core/src/retention.rs
@@ -283,6 +283,7 @@ pub fn ftrl_soft_threshold_backward(
     lambda: f32,
 ) -> Vec<f32> {
     debug_assert_eq!(d_w.len(), accum.len());
+    debug_assert!(lambda >= 0.0, "FTRL lambda must be non-negative, got {lambda}");
 
     d_w.iter()
         .zip(accum.iter())
@@ -304,6 +305,7 @@ pub fn ftrl_soft_threshold_backward_inplace(
 ) {
     debug_assert_eq!(d_w.len(), accum.len());
     debug_assert_eq!(d_w.len(), d_accum.len());
+    debug_assert!(lambda >= 0.0, "FTRL lambda must be non-negative, got {lambda}");
 
     for i in 0..d_w.len() {
         d_accum[i] = if accum[i].abs() > lambda { d_w[i] } else { 0.0 };


### PR DESCRIPTION
## Summary
- Implement FTRL elastic net accumulator pattern (MIRAS §3.2 Eq 23): `A -= eta*grad` then `W = soft_threshold(A, lambda)`
- Accumulator A is a separate `inner_loop_state` tensor alongside memory W — tracks cumulative gradient sum while W is the regularized solution
- Add STE backward for soft thresholding: `dL/dA = dL/dW * indicator(|A| > lambda)` — gradient passes through active entries, zeroed for killed entries
- Both allocating and in-place backward variants provided

## Test plan
- [x] 6 new FTRL tests: test_ftrl_elastic_net_step_basic, test_ftrl_accumulates_across_steps, test_ftrl_zero_lambda_no_thresholding, test_ftrl_backward_ste_basic, test_ftrl_backward_inplace_matches, test_ftrl_backward_zero_lambda_all_pass
- [x] All 957 lib tests pass
- [x] All integration tests pass

Closes PS-TB-04 (task_5ad39f)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for elastic-net based optimization with forward and backward pass support, enabling improved model training capabilities.
  
* **Tests**
  * Expanded test coverage including forward step behavior, multi-step accumulation, and gradient computation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->