### PR TITLE
PS-TB-05: Inner-loop Newton-Schulz with generalized zeta + batched chunk NS

### DIFF
--- a/core/src/m3.rs
+++ b/core/src/m3.rs
@@ -275,7 +275,10 @@ pub fn newton_schulz_5(s: &[f32], d: usize, iterations: usize) -> Vec<f32> {
 /// * `s` — input momentum/gradient matrix [d*d], row-major
 /// * `d` — matrix dimension (s must be d×d)
 /// * `iterations` — number of NS iterations (Atlas default: 5)
-/// * `zetas` — per-iteration step sizes. None = all 1.0. Must have length == iterations.
+/// * `zetas` — per-iteration step sizes, length must equal `iterations`.
+///   **Warning**: `None` defaults to all 1.0, which diverges for non-orthogonal
+///   inputs (the gradient term grows cubically in ||O||). Use `zeta ≈ 0.25` for
+///   stable convergence matching the classical NS polynomial coefficients (3/2, -1/2).
 ///
 /// Source: HOPE (2512.24695) §4.2 Eq 44; Atlas (2505.23735) §5 Eq 32
 pub fn newton_schulz_inner(


### PR DESCRIPTION
## Summary
- Adds `newton_schulz_inner()` — inner-loop NS variant (HOPE §4.2 Eq 44) with per-iteration configurable zeta step sizes and G-anchor throughout iteration
- Adds `newton_schulz_batched()` — applies NS independently to C d×d matrices for Atlas chunk-parallel training (§5.1 Eqs 39-41)
- Existing `newton_schulz_5()` (outer-loop classical polynomial form) unchanged

## Key design decisions
- Inner-loop form uses gradient descent on `L_orth + proximity-to-G` objective, unlike outer-loop polynomial form
- `zeta=0.25` recovers first-step coefficients matching classical NS (3/2, -1/2)
- Batched version is CPU reference (sequential loop); GPU would be a single batched op
- Both functions share the same Frobenius normalization for convergence

## Test plan
- [x] 9 new tests: identity, orthogonalization (zeta=0.25), custom zetas, determinism, zero iterations, near-zero, batch-matches-individual, batch-with-zetas, batch-single
- [x] All 16 m3 tests pass (7 existing + 9 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added enhanced numerical utilities with configurable iteration control, optional per-iteration step sizing, and batch processing support for greater computational flexibility.

* **Tests**
  * Expanded coverage to validate identity/behavioral properties, determinism, zero-iteration behavior, and equivalence between batched and individual processing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->