### PR TITLE
Replace per-call cudaMalloc/cudaFree with persistent buffer pools in SwiGLU kernels

### DIFF
--- a/core/kernels/swiglu_backward.cu
+++ b/core/kernels/swiglu_backward.cu
@@ -222,6 +222,12 @@ extern "C" void swiglu_backward_f32_cuda(
     int d_model,
     int intermediate)
 {
+    if (seq_len <= 0 || d_model <= 0 || intermediate <= 0) {
+        fprintf(stderr,
+                "[NL_Hecate FATAL] swiglu_bwd invalid dims: seq_len=%d d_model=%d intermediate=%d\n",
+                seq_len, d_model, intermediate);
+        abort();
+    }
     cublasHandle_t h = get_cublas_handle_bwd();
     const float alpha1 = 1.0f, beta0 = 0.0f, beta1 = 1.0f;
 

--- a/core/kernels/swiglu_forward.cu
+++ b/core/kernels/swiglu_forward.cu
@@ -179,6 +179,12 @@ extern "C" void swiglu_forward_f32_cuda(
     int d_model,
     int intermediate)
 {
+    if (seq_len <= 0 || d_model <= 0 || intermediate <= 0) {
+        fprintf(stderr,
+                "[NL_Hecate FATAL] swiglu_fwd invalid dims: seq_len=%d d_model=%d intermediate=%d\n",
+                seq_len, d_model, intermediate);
+        abort();
+    }
     cublasHandle_t h = get_cublas_handle_fwd();
     const float alpha1 = 1.0f, beta0 = 0.0f;
 


### PR DESCRIPTION
## Summary

- **`swiglu_forward.cu`**: Replaces 9 per-call `cudaMalloc`/`cudaFree` calls with a static `g_fwd_pool` struct. Allocated once on first call for a given `(d, inter, seq_len)` triple; re-allocated only if dimensions change. Weights are still H2D every call (they change after each AdamW step); intermediates stay on device.
- **`swiglu_backward.cu`**: Same pattern — replaces 16 per-call allocations with a static `g_bwd_pool` struct covering all input, scratch, and output gradient buffers.

**Motivation**: At `d=2048, inter=8192` each forward call was allocating and freeing ~67 MB of device memory per step. Per-step `cudaMalloc/cudaFree` dominated wall-clock time. With persistent pools, device memory is allocated once at training startup and reused for the lifetime of the process. A single training run uses a fixed `(d, inter, seq_len)` config so one shared pool is sufficient per kernel.

## Graph Gate

- `swiglu-forward-cu` → CS-44 (hardware-dependent optimization) ✓ (new edge — buffer pool is a profiling-driven A6000 target optimization)
- `swiglu_backward` → CS-44 ✓ (new edge)

## Test plan

- [ ] `cargo test --features cuda --test test_swiglu_cuda -- --nocapture` — all 4 parity tests pass (forward/backward/finite/seq=1)
- [ ] Verify no regression: forward tolerance 1e-5, backward tolerance 1e-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced persistent GPU buffer pools and persistent cuBLAS handles to eliminate per-call allocations and reduce CUDA overhead for forward and backward passes.

* **Reliability**
  * Added guarded allocation/reallocation, stale-buffer cleanup, mutex protection, and grid-size safety checks to improve stability during dimension changes.

* **Compatibility**
  * Public forward/backward function signatures remain unchanged; inputs are uploaded per call, and pools are reused (not safe for concurrent calls—sequential execution expected).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->