### PR TITLE
perf: reduce eval probe overhead (probe_max_tokens, probe_prompts, tape_every)

### DIFF
--- a/python/engine/config.py
+++ b/python/engine/config.py
@@ -90,6 +90,12 @@ class BuildConfig:
     eval_every: int = 0  # 0 = disabled; evaluate on val set every N steps
     eval_max_chunks: int = 100  # max chunks per eval pass
 
+    # Probe tuning (learning probes fire at every eval; these control their cost)
+    probe_max_tokens: int = 20   # tokens generated per learning probe (was hardcoded 60)
+    probe_prompts: int = 1       # how many EVAL_PROMPTS to run for probe1 (1–4)
+    tape_every: int = 0          # 0 = same as eval_every; set to a multiple (e.g. 4×) to run
+    #                            # tape_forward_summary less often (it runs a CPU forward pass)
+
     # Gradient checkpointing (VRAM optimization for memory rules)
     checkpoint_interval: int | None = None  # None = full trajectory; C = store M every C steps
 

--- a/python/engine/loop.py
+++ b/python/engine/loop.py
@@ -298,7 +298,10 @@ def run_build(bcfg: BuildConfig):
         print(f"  Grad clip: max_norm={bcfg.max_grad_norm}")
     print(f"  Device:   {'GPU' if use_gpu else 'CPU'}")
     if bcfg.eval_every > 0:
+        tape_eff_disp = bcfg.tape_every if bcfg.tape_every > 0 else bcfg.eval_every
         print(f"  Eval:     every {bcfg.eval_every} steps, {bcfg.eval_max_chunks} max chunks")
+        print(f"  Probes:   {bcfg.probe_prompts} prompt(s), {bcfg.probe_max_tokens} tokens each  "
+              f"| tape every {tape_eff_disp} steps")
     if bcfg.log_file:
         print(f"  Log:      {bcfg.log_file}")
     print(f"{'=' * 60}\n")
@@ -763,7 +766,9 @@ def run_build(bcfg: BuildConfig):
             print(f"  [eval] step {step:5d}  loss={eval_loss:.4f}  ppl={eval_ppl:.1f}")
             if gpu_model is not None and hasattr(gpu_model, "gate_biases"):
                 print_level_metrics(gpu_model, bcfg.k)
-            if (gpu_model is not None
+            tape_eff = bcfg.tape_every if bcfg.tape_every > 0 else bcfg.eval_every
+            if (tape_eff > 0 and step % tape_eff == 0
+                    and gpu_model is not None
                     and hasattr(gpu_model, "tape_forward_summary")
                     and input_ids is not None and target_ids is not None
                     and max(target_ids) < bcfg.vocab_size):
@@ -791,13 +796,14 @@ def run_build(bcfg: BuildConfig):
                     snapshot = full_snapshot(gpu_model)
                     # Probe 1: within-generation learning curve
                     # Restore between probes: step_generate modifies params
-                    for prompt_text in EVAL_PROMPTS:
+                    n_prompts = max(1, min(bcfg.probe_prompts, len(EVAL_PROMPTS)))
+                    for prompt_text in EVAL_PROMPTS[:n_prompts]:
                         full_restore(gpu_model, snapshot)
                         gpu_model.reset_optimizer()
                         prompt_ids = tokenizer.encode(prompt_text)
                         result = probe_within_generation(
                             gpu_model, cfg, prompt_ids, tokenizer,
-                            max_tokens=60, temperature=0.7, lr=bcfg.lr)
+                            max_tokens=bcfg.probe_max_tokens, temperature=0.7, lr=bcfg.lr)
                         preview = result["generated_text"][:60].replace("\n", "\\n")
                         print(f"    [probe1] \"{prompt_text}\" → \"{preview}\"")
                         print(f"      loss: {result['loss_first10_avg']:.4f} → "
@@ -819,7 +825,8 @@ def run_build(bcfg: BuildConfig):
                     prompt_ids = tokenizer.encode(prompt_text)
                     xresult = probe_cross_exposure(
                         gpu_model, cfg, prompt_ids, tokenizer,
-                        max_tokens=30, temperature=0.7, lr=bcfg.lr)
+                        max_tokens=max(10, bcfg.probe_max_tokens // 2),
+                        temperature=0.7, lr=bcfg.lr)
                     print(f"    [probe2] \"{prompt_text}\" "
                           f"run1={xresult['run1_avg_loss']:.4f} → "
                           f"run2={xresult['run2_avg_loss']:.4f}  "


### PR DESCRIPTION
## Summary

- **Root cause found**: each eval cycle at `eval_every=250` cost 626s on diagnostics vs only 440s training. The 5 learning probes (4 `within_gen` + 1 `cross_exposure`) each ran 60 tokens at batch=1/seq_len=512, costing ~97s per probe due to 60 sequential CUDA-sync barriers. `tape_forward_summary` ran the full Wengert-tape forward **on CPU** every eval = 135s.
- **Three new `BuildConfig` fields** (all backward-compatible; defaults give faster behavior):
  - `probe_max_tokens: int = 20` — tokens per probe (was hardcoded 60)
  - `probe_prompts: int = 1` — how many EVAL_PROMPTS to run for probe1 (was all 4)
  - `tape_every: int = 0` — 0 = same as `eval_every`; set to a multiple (e.g. 1000) to run the expensive CPU tape pass less often
- **Expected improvement** (at `eval_every=250`, defaults):
  - Before: ~626s eval overhead (135 tape + 485 probes + 1 vocab)
  - After: ~50s eval overhead (2 × 24s probes + 1s vocab + tape at eval freq)
  - With `tape_every=1000`: tape only fires 4× less often → apparent throughput ~2100 tok/s vs previous ~960 tok/s

## Test plan

- [ ] Existing config files (no new fields) parse cleanly — verified with `BuildConfig.from_file`
- [ ] `probe_prompts=1` runs only `EVAL_PROMPTS[0]` for probe1
- [ ] `probe_max_tokens=20` propagates to both within_gen (20 tokens) and cross_exposure (10 tokens via `max(10, 20//2)`)
- [ ] `tape_every=1000` with `eval_every=250` runs tape at steps 1000, 2000, 3000 (skips 250, 500, 750)
- [ ] Startup print shows probe config line
- [ ] GPU0/GPU1 currently running are unaffected (changes take effect on next run start)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced three new configuration options to customize probe operations: maximum tokens per generation probe, number of prompts to evaluate, and tape interval frequency.
  * Enhanced evaluation output to display probe configuration details and tape operation scheduling alongside evaluation metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->